### PR TITLE
Upgrade Mojo integration to direct Python import

### DIFF
--- a/prisoners-benchmark/.gitignore
+++ b/prisoners-benchmark/.gitignore
@@ -1,0 +1,11 @@
+# Rust build artifacts
+bench_rust/target/
+bench_rust/Cargo.lock
+
+# Python
+__pycache__/
+*.pyc
+.venv/
+
+# uv
+uv.lock

--- a/prisoners-benchmark/README.md
+++ b/prisoners-benchmark/README.md
@@ -1,0 +1,41 @@
+# Prisoner Simulation Benchmarks
+
+Performance comparison of different implementations for the [100 prisoners problem](https://en.wikipedia.org/wiki/100_prisoners_problem) simulation.
+
+## Results
+
+| Implementation | Speedup vs Python |
+|---------------|-------------------|
+| Pure Python   | 1.0x (baseline)   |
+| NumPy         | 0.6x (slower)     |
+| Numba         | ~4x               |
+| Mojo          | ~5x               |
+| Rust          | ~7x               |
+
+## Setup
+
+```bash
+cd prisoners-benchmark
+uv sync
+```
+
+### Build Rust extension (optional)
+
+```bash
+uv run maturin develop --manifest-path bench_rust/Cargo.toml --release
+```
+
+## Run benchmarks
+
+```bash
+uv run marimo edit run_benchmarks.py
+```
+
+## Files
+
+- `run_benchmarks.py` - Interactive Marimo notebook with all benchmarks
+- `bench_python.py` - Pure Python and NumPy implementations
+- `bench_numba.py` - Numba JIT implementation
+- `bench_mojo.mojo` - Standalone Mojo benchmark
+- `bench_mojo_runner.mojo` - Mojo with CLI args for Python integration
+- `bench_rust/` - Rust PyO3 extension

--- a/prisoners-benchmark/bench_mojo.mojo
+++ b/prisoners-benchmark/bench_mojo.mojo
@@ -1,0 +1,81 @@
+from random import random_ui64, seed
+from python import PythonObject, Python
+from python.bindings import PythonModuleBuilder
+
+
+fn max_cycle_length(perm: List[Int]) -> Int:
+    """Find the maximum cycle length in a permutation."""
+    var n = len(perm)
+    var visited = List[Bool](capacity=n)
+    for _ in range(n):
+        visited.append(False)
+
+    var max_len = 0
+    for start in range(n):
+        if visited[start]:
+            continue
+        var length = 0
+        var current = start
+        while not visited[current]:
+            visited[current] = True
+            length += 1
+            current = perm[current]
+        if length > max_len:
+            max_len = length
+    return max_len
+
+
+fn fisher_yates_shuffle(mut perm: List[Int]):
+    """Shuffle a list in place using Fisher-Yates algorithm."""
+    var n = len(perm)
+    for i in range(n - 1, 0, -1):
+        var j = Int(random_ui64(0, i))
+        var tmp = perm[i]
+        perm[i] = perm[j]
+        perm[j] = tmp
+
+
+fn simulate_mojo_internal(n_prisoners: Int, n_sims: Int) -> List[Int]:
+    """Run n_sims simulations and return max cycle lengths."""
+    var results = List[Int](capacity=n_sims)
+
+    for _ in range(n_sims):
+        var perm = List[Int](capacity=n_prisoners)
+        for i in range(n_prisoners):
+            perm.append(i)
+        fisher_yates_shuffle(perm)
+        results.append(max_cycle_length(perm))
+
+    return results^
+
+
+fn simulate_mojo_wrapper(
+    n_prisoners_obj: PythonObject,
+    n_sims_obj: PythonObject
+) raises -> PythonObject:
+    """Python-callable wrapper that converts types and returns Python list."""
+    var n_prisoners = Int(n_prisoners_obj)
+    var n_sims = Int(n_sims_obj)
+
+    var mojo_results = simulate_mojo_internal(n_prisoners, n_sims)
+
+    var py_list = Python.list()
+    for i in range(len(mojo_results)):
+        py_list.append(mojo_results[i])
+
+    return py_list
+
+
+@export
+fn PyInit_bench_mojo() -> PythonObject:
+    """Module initialization function required by Python's import system."""
+    seed()  # Initialize RNG once at module load time
+    try:
+        var m = PythonModuleBuilder("bench_mojo")
+        m.def_function[simulate_mojo_wrapper](
+            "simulate_mojo",
+            docstring="Run prisoner simulation. Args: n_prisoners (int), n_sims (int). Returns: list[int]"
+        )
+        return m.finalize()
+    except:
+        return PythonObject()

--- a/prisoners-benchmark/bench_mojo_runner.mojo
+++ b/prisoners-benchmark/bench_mojo_runner.mojo
@@ -1,0 +1,73 @@
+from random import random_ui64, seed
+from time import perf_counter_ns
+from sys import argv
+
+
+fn max_cycle_length(perm: List[Int]) -> Int:
+    """Find the maximum cycle length in a permutation."""
+    var n = len(perm)
+    var visited = List[Bool](capacity=n)
+    for _ in range(n):
+        visited.append(False)
+
+    var max_len = 0
+    for start in range(n):
+        if visited[start]:
+            continue
+        var length = 0
+        var current = start
+        while not visited[current]:
+            visited[current] = True
+            length += 1
+            current = perm[current]
+        if length > max_len:
+            max_len = length
+    return max_len
+
+
+fn fisher_yates_shuffle(mut perm: List[Int]):
+    """Shuffle a list in place using Fisher-Yates algorithm."""
+    var n = len(perm)
+    for i in range(n - 1, 0, -1):
+        var j = Int(random_ui64(0, i))
+        var tmp = perm[i]
+        perm[i] = perm[j]
+        perm[j] = tmp
+
+
+fn simulate_mojo(n_prisoners: Int, n_sims: Int) -> List[Int]:
+    """Run n_sims simulations and return max cycle lengths."""
+    seed()
+    var results = List[Int](capacity=n_sims)
+
+    for _ in range(n_sims):
+        var perm = List[Int](capacity=n_prisoners)
+        for i in range(n_prisoners):
+            perm.append(i)
+        fisher_yates_shuffle(perm)
+        results.append(max_cycle_length(perm))
+
+    return results^
+
+
+fn main() raises:
+    # Parse command line arguments
+    var args = argv()
+    var n_prisoners = 100
+    var n_sims = 10000
+
+    if len(args) > 1:
+        n_prisoners = atol(args[1])
+    if len(args) > 2:
+        n_sims = atol(args[2])
+
+    var start = perf_counter_ns()
+    var results = simulate_mojo(n_prisoners, n_sims)
+    var elapsed_ns = perf_counter_ns() - start
+    var elapsed_s = Float64(elapsed_ns) / 1_000_000_000.0
+
+    # Output in parseable format: elapsed_seconds,result1,result2,...
+    print(elapsed_s, end="")
+    for i in range(len(results)):
+        print(",", results[i], sep="", end="")
+    print()

--- a/prisoners-benchmark/bench_numba.py
+++ b/prisoners-benchmark/bench_numba.py
@@ -1,0 +1,56 @@
+"""Numba JIT-compiled implementation for benchmarking."""
+
+import numpy as np
+from numba import njit
+
+
+@njit
+def max_cycle_length_numba(perm):
+    """Find the maximum cycle length in a permutation (Numba JIT)."""
+    n = len(perm)
+    visited = np.zeros(n, dtype=np.bool_)
+    max_len = 0
+    for start in range(n):
+        if visited[start]:
+            continue
+        length = 0
+        current = start
+        while not visited[current]:
+            visited[current] = True
+            length += 1
+            current = perm[current]
+        if length > max_len:
+            max_len = length
+    return max_len
+
+
+def simulate_numba(n_prisoners: int, n_sims: int) -> list[int]:
+    """Run simulations using Numba JIT-compiled function."""
+    results = []
+    for _ in range(n_sims):
+        perm = np.random.permutation(n_prisoners).astype(np.int64)
+        results.append(max_cycle_length_numba(perm))
+    return results
+
+
+def warmup():
+    """Warm up Numba JIT compilation."""
+    perm = np.random.permutation(100).astype(np.int64)
+    max_cycle_length_numba(perm)
+
+
+if __name__ == "__main__":
+    import time
+
+    N_PRISONERS = 100
+    N_SIMS = 10_000
+
+    print("Warming up Numba JIT...")
+    warmup()
+
+    print(f"\nBenchmarking with {N_PRISONERS} prisoners, {N_SIMS} simulations\n")
+
+    start = time.perf_counter()
+    results = simulate_numba(N_PRISONERS, N_SIMS)
+    elapsed = time.perf_counter() - start
+    print(f"Numba JIT: {elapsed:.3f}s for {N_SIMS} sims ({N_SIMS/elapsed:.0f} sims/sec)")

--- a/prisoners-benchmark/bench_python.py
+++ b/prisoners-benchmark/bench_python.py
@@ -1,0 +1,80 @@
+"""Baseline Python implementation for benchmarking."""
+
+import random
+import numpy as np
+import time
+
+
+def max_cycle_length_python(perm):
+    """Find the maximum cycle length in a permutation (pure Python)."""
+    n = len(perm)
+    visited = [False] * n
+    max_len = 0
+    for start in range(n):
+        if visited[start]:
+            continue
+        length = 0
+        current = start
+        while not visited[current]:
+            visited[current] = True
+            length += 1
+            current = perm[current]
+        if length > max_len:
+            max_len = length
+    return max_len
+
+
+def max_cycle_length_numpy(perm):
+    """Find the maximum cycle length using NumPy arrays."""
+    n = len(perm)
+    visited = np.zeros(n, dtype=bool)
+    max_len = 0
+    for start in range(n):
+        if visited[start]:
+            continue
+        length = 0
+        current = start
+        while not visited[current]:
+            visited[current] = True
+            length += 1
+            current = perm[current]
+        if length > max_len:
+            max_len = length
+    return max_len
+
+
+def simulate_python(n_prisoners: int, n_sims: int) -> list[int]:
+    """Run simulations using pure Python."""
+    results = []
+    for _ in range(n_sims):
+        perm = np.random.permutation(n_prisoners)
+        results.append(max_cycle_length_python(perm))
+    return results
+
+
+def simulate_numpy(n_prisoners: int, n_sims: int) -> list[int]:
+    """Run simulations using NumPy arrays."""
+    results = []
+    for _ in range(n_sims):
+        perm = np.random.permutation(n_prisoners)
+        results.append(max_cycle_length_numpy(perm))
+    return results
+
+
+def benchmark(func, n_prisoners: int, n_sims: int, name: str) -> float:
+    """Benchmark a simulation function and return elapsed time."""
+    start = time.perf_counter()
+    results = func(n_prisoners, n_sims)
+    elapsed = time.perf_counter() - start
+    print(f"{name}: {elapsed:.3f}s for {n_sims} sims ({n_sims/elapsed:.0f} sims/sec)")
+    return elapsed
+
+
+if __name__ == "__main__":
+    N_PRISONERS = 100
+    N_SIMS = 10_000  # Use 10k for quick benchmarks, 100k for full test
+
+    print(f"Benchmarking with {N_PRISONERS} prisoners, {N_SIMS} simulations\n")
+
+    benchmark(simulate_python, N_PRISONERS, N_SIMS, "Pure Python")
+    benchmark(simulate_numpy, N_PRISONERS, N_SIMS, "NumPy arrays")

--- a/prisoners-benchmark/bench_rust/Cargo.toml
+++ b/prisoners-benchmark/bench_rust/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "bench_rust"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "bench_rust"
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = { version = "0.27", features = ["extension-module"] }
+rand = "0.8"

--- a/prisoners-benchmark/bench_rust/pyproject.toml
+++ b/prisoners-benchmark/bench_rust/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "bench_rust"
+version = "0.1.0"
+requires-python = ">=3.8"
+
+[tool.maturin]
+features = ["pyo3/extension-module"]

--- a/prisoners-benchmark/bench_rust/src/lib.rs
+++ b/prisoners-benchmark/bench_rust/src/lib.rs
@@ -1,0 +1,50 @@
+use pyo3::prelude::*;
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+
+/// Find the maximum cycle length in a single permutation.
+fn max_cycle_length(perm: &[usize]) -> usize {
+    let n = perm.len();
+    let mut visited = vec![false; n];
+    let mut max_len = 0;
+
+    for start in 0..n {
+        if visited[start] {
+            continue;
+        }
+        let mut length = 0;
+        let mut current = start;
+        while !visited[current] {
+            visited[current] = true;
+            length += 1;
+            current = perm[current];
+        }
+        if length > max_len {
+            max_len = length;
+        }
+    }
+    max_len
+}
+
+/// Run n_sims simulations and return the max cycle length for each.
+#[pyfunction]
+fn simulate_rust(n_prisoners: usize, n_sims: usize) -> Vec<usize> {
+    let mut rng = thread_rng();
+    let mut results = Vec::with_capacity(n_sims);
+
+    for _ in 0..n_sims {
+        // Create and shuffle permutation
+        let mut perm: Vec<usize> = (0..n_prisoners).collect();
+        perm.shuffle(&mut rng);
+
+        results.push(max_cycle_length(&perm));
+    }
+    results
+}
+
+/// Python module
+#[pymodule]
+fn bench_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(simulate_rust, m)?)?;
+    Ok(())
+}

--- a/prisoners-benchmark/pyproject.toml
+++ b/prisoners-benchmark/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "prisoners-benchmark"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "altair<5.5",
+    "marimo",
+    "maturin>=1.11.4",
+    "max",
+    "numba",
+    "numpy",
+    "pandas",
+    "tabulate>=0.9.0",
+]

--- a/prisoners-benchmark/requirements.txt
+++ b/prisoners-benchmark/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+numba
+maturin

--- a/prisoners-benchmark/run_benchmarks.py
+++ b/prisoners-benchmark/run_benchmarks.py
@@ -1,0 +1,278 @@
+# /// script
+# requires-python = ">=3.12,<3.14"
+# dependencies = [
+#     "marimo",
+#     "max",
+#     "numba",
+#     "numpy",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.18.4"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    import time
+    import sys
+    import subprocess
+    import shutil
+    import os
+    import numpy as np
+    return mo, np, os, sys, time
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    # Prisoner Simulation Benchmark
+
+    Comparing different implementations of the prisoner simulation:
+    - **Pure Python** - baseline with Python lists
+    - **NumPy** - using NumPy arrays
+    - **Numba** - JIT-compiled with `@njit`
+    - **Rust** - native extension via PyO3
+    - **Mojo** - Modular's high-performance language
+    """)
+    return
+
+
+@app.cell
+def _():
+    from bench_python import simulate_python, simulate_numpy
+    from bench_numba import simulate_numba, warmup as warmup_numba
+    return simulate_numba, simulate_numpy, simulate_python, warmup_numba
+
+
+@app.cell
+def _():
+    # Try to import Rust implementation
+    try:
+        from bench_rust import simulate_rust
+        RUST_AVAILABLE = True
+    except ImportError:
+        simulate_rust = None
+        RUST_AVAILABLE = False
+    return RUST_AVAILABLE, simulate_rust
+
+
+@app.cell
+def _(os, sys, time):
+    # Mojo implementation - direct import via mojo.importer
+    import mojo.importer
+
+    # Add the prisoners-benchmark directory to sys.path if needed
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    if script_dir not in sys.path:
+        sys.path.insert(0, script_dir)
+
+    from bench_mojo import simulate_mojo as simulate_mojo_direct
+
+    def simulate_mojo_wrapper(n_prisoners: int, n_sims: int) -> tuple[float, list[int]]:
+        """Run Mojo simulation. Returns (elapsed_time, results)."""
+        start = time.perf_counter()
+        results = simulate_mojo_direct(n_prisoners, n_sims)
+        elapsed = time.perf_counter() - start
+        return elapsed, list(results)
+    return (simulate_mojo_wrapper,)
+
+
+@app.cell(hide_code=True)
+def _(RUST_AVAILABLE, mo):
+    _notes = []
+    if not RUST_AVAILABLE:
+        _notes.append("**Rust** not available. Build with: `cd bench_rust && maturin develop --release`")
+
+    mo.md("> " + "\n>\n> ".join(_notes)) if _notes else None
+    return
+
+
+@app.cell
+def _(np, time):
+    def benchmark(func, n_prisoners: int, n_sims: int, name: str) -> tuple[float, list]:
+        """Benchmark a simulation function. Returns (elapsed_time, results)."""
+        start = time.perf_counter()
+        results = func(n_prisoners, n_sims)
+        elapsed = time.perf_counter() - start
+        return elapsed, results
+
+
+    def verify_distribution(results1: list, results2: list, name1: str, name2: str, tolerance: float = 0.05) -> bool:
+        """Check that two result distributions are similar (statistical sanity check)."""
+        mean1, mean2 = np.mean(results1), np.mean(results2)
+        print(mean1, mean2)
+        relative_diff = abs(mean1 - mean2) / max(mean1, mean2)
+        return relative_diff < tolerance
+    return benchmark, verify_distribution
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## Configuration
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    n_sims_input = mo.ui.slider(
+        value=10_000, start=1_000, stop=100_000, step=1_000, label="Number of simulations"
+    )
+    n_sims_input
+    return (n_sims_input,)
+
+
+@app.cell
+def _(n_sims_input):
+    N_PRISONERS = 100
+    N_SIMS = n_sims_input.value
+    return N_PRISONERS, N_SIMS
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## Run Benchmark
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    run_button = mo.ui.button(label="🚀 Run Benchmarks")
+    run_button
+    return (run_button,)
+
+
+@app.cell
+def _(
+    N_PRISONERS,
+    N_SIMS,
+    RUST_AVAILABLE,
+    benchmark,
+    run_button,
+    simulate_mojo_wrapper,
+    simulate_numba,
+    simulate_numpy,
+    simulate_python,
+    simulate_rust,
+    warmup_numba,
+):
+    # Trigger on button click
+    run_button
+
+    # Warm up Numba
+    warmup_numba()
+
+    # Run benchmarks
+    results_dict = {}
+
+    # Pure Python
+    elapsed, results = benchmark(simulate_python, N_PRISONERS, N_SIMS, "Pure Python")
+    results_dict["Pure Python"] = (elapsed, results)
+
+    # NumPy
+    elapsed, results = benchmark(simulate_numpy, N_PRISONERS, N_SIMS, "NumPy")
+    results_dict["NumPy"] = (elapsed, results)
+
+    # Numba
+    elapsed, results = benchmark(simulate_numba, N_PRISONERS, N_SIMS, "Numba")
+    results_dict["Numba"] = (elapsed, results)
+
+    # Rust (if available)
+    if RUST_AVAILABLE:
+        elapsed, results = benchmark(simulate_rust, N_PRISONERS, N_SIMS, "Rust")
+        results_dict["Rust"] = (elapsed, results)
+
+    # Mojo
+    elapsed, results = simulate_mojo_wrapper(N_PRISONERS, N_SIMS)
+    results_dict["Mojo"] = (elapsed, results)
+
+    {k: v[0] for k, v in results_dict.items()}
+    return (results_dict,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## Results
+    """)
+    return
+
+
+@app.cell
+def _(N_PRISONERS, N_SIMS, mo, results_dict):
+    # Calculate speedups
+    _baseline = results_dict["Pure Python"][0]
+
+    _rows = []
+    for _name, (_elapsed, _) in results_dict.items():
+        _speedup = _baseline / _elapsed
+        _rows.append({
+            "Implementation": _name,
+            "Time (s)": f"{_elapsed:.3f}",
+            "Sims/sec": f"{N_SIMS/_elapsed:,.0f}",
+            "Speedup": f"{_speedup:.1f}x",
+        })
+
+    import pandas as pd
+    _results_df = pd.DataFrame(_rows)
+
+    mo.md(f"""
+    **Parameters:** {N_PRISONERS} prisoners, {N_SIMS:,} simulations
+
+    {_results_df.to_markdown(index=False)}
+    """)
+
+    print(_results_df.to_markdown(index=False))
+    return
+
+
+@app.cell
+def _():
+    _results_df.to_markdown(index=False)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## Distribution Verification
+    """)
+    return
+
+
+@app.cell
+def _(results_dict):
+    results_dict
+    return
+
+
+@app.cell
+def _(results_dict, verify_distribution):
+    _baseline_results = results_dict["Pure Python"][1]
+    _verification = []
+    for _name, (_, _results) in results_dict.items():
+        if _name == "Pure Python":
+            continue
+        _ok = verify_distribution(_baseline_results, _results, "Pure Python", _name)
+        _status = "✓" if _ok else "✗"
+        _verification.append(f"- {_name}: {_status}")
+
+    _all_ok = all("✓" in v for v in _verification)
+    _summary = "All distributions match!" if _all_ok else "Warning: Some distributions differ"
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
## Summary
- Replace subprocess-based Mojo execution with direct Python-to-Mojo integration using `mojo.importer` and `PythonModuleBuilder`
- Eliminates subprocess overhead (~50-100ms per call) and provides cleaner integration matching the Rust/PyO3 pattern
- Consolidate duplicate benchmark notebooks and fix RNG seeding
- Use `np.random.permutation` consistently across all Python/NumPy implementations

## Test plan
- Run `uv run python` and verify `from bench_mojo import simulate_mojo` works
- Run Marimo notebook: `uv run marimo run run_benchmarks.py`
- Verify all implementations produce different random results on each run

🤖 Generated with [Claude Code](https://claude.com/claude-code)