### PR TITLE
Add GRPO vs GDPO interactive widget

### DIFF
--- a/grpo_gdpo_widget/__init__.py
+++ b/grpo_gdpo_widget/__init__.py
@@ -1,0 +1,3 @@
+from .widget import GrpoGdpoWidget
+
+__all__ = ["GrpoGdpoWidget"]

--- a/grpo_gdpo_widget/grpo_gdpo_widget.py
+++ b/grpo_gdpo_widget/grpo_gdpo_widget.py
@@ -1,0 +1,73 @@
+# /// script
+# requires-python = ">=3.12,<3.14"
+# dependencies = ["marimo", "anywidget", "traitlets"]
+# ///
+
+import marimo
+
+__generated_with = "0.19.2"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    from widget import GrpoGdpoWidget
+    return GrpoGdpoWidget, mo
+
+
+@app.cell
+def _(GrpoGdpoWidget):
+    widget = GrpoGdpoWidget()
+    return (widget,)
+
+
+@app.cell
+def _(mo, widget):
+    widget_view = mo.ui.anywidget(widget)
+    return (widget_view,)
+
+
+@app.cell
+def _(widget_view):
+    widget_view
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## GRPO vs GDPO Advantage Comparison
+
+    This widget demonstrates the difference between **GRPO** (Group Relative Policy Optimization)
+    and **GDPO** (Group reward-Decoupled Policy Optimization) advantage calculations.
+
+    **Click on the reward cells** (0 or 1) to toggle values and see how the advantages change.
+
+    ### Formulas
+
+    **GRPO** first aggregates rewards, then normalizes:
+
+    $$r_j = r_j^{(1)} + r_j^{(2)} + \ldots + r_j^{(n)}$$
+
+    $$A_j^{\text{GRPO}} = \frac{r_j - \mu(r)}{\sigma(r)}$$
+
+    **GDPO** normalizes each reward dimension separately, then sums:
+
+    $$A_j^{(i)} = \frac{r_j^{(i)} - \mu(r^{(i)})}{\sigma(r^{(i)})}$$
+
+    $$A_j^{\text{GDPO}} = A_j^{(1)} + A_j^{(2)} + \ldots + A_j^{(n)}$$
+
+    ### Key Insight
+
+    When different reward combinations produce the same total (e.g., `[1,0,1]` and `[0,1,1]` both sum to 2),
+    GRPO assigns identical advantages, while GDPO can distinguish them based on which specific
+    rewards were achieved.
+
+    The **Difference** column highlights when GDPO preserves information that GRPO loses.
+    """)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/grpo_gdpo_widget/grpo_gdpo_widget.py
+++ b/grpo_gdpo_widget/grpo_gdpo_widget.py
@@ -1,37 +1,18 @@
 # /// script
 # requires-python = ">=3.12,<3.14"
-# dependencies = ["marimo", "anywidget", "traitlets"]
+# dependencies = [
+#     "marimo",
+#     "anywidget",
+#     "traitlets",
+#     "numpy==2.4.1",
+#     "matplotlib==3.10.8",
+# ]
 # ///
 
 import marimo
 
 __generated_with = "0.19.2"
 app = marimo.App(width="medium")
-
-
-@app.cell
-def _():
-    import marimo as mo
-    from widget import GrpoGdpoWidget
-    return GrpoGdpoWidget, mo
-
-
-@app.cell
-def _(GrpoGdpoWidget):
-    widget = GrpoGdpoWidget()
-    return (widget,)
-
-
-@app.cell
-def _(mo, widget):
-    widget_view = mo.ui.anywidget(widget)
-    return (widget_view,)
-
-
-@app.cell
-def _(widget_view):
-    widget_view
-    return
 
 
 @app.cell(hide_code=True)
@@ -66,6 +47,159 @@ def _(mo):
 
     The **Difference** column highlights when GDPO preserves information that GRPO loses.
     """)
+    return
+
+
+@app.cell
+def _():
+    import marimo as mo
+    from widget import GrpoGdpoWidget
+    return GrpoGdpoWidget, mo
+
+
+@app.cell
+def _(GrpoGdpoWidget):
+    widget = GrpoGdpoWidget()
+    return (widget,)
+
+
+@app.cell
+def _(mo, widget):
+    widget_view = mo.ui.anywidget(widget)
+    return (widget_view,)
+
+
+@app.cell
+def _(widget_view):
+    widget_view
+    return
+
+
+@app.cell
+def _():
+    import numpy as np
+
+    def normalize(arr):
+        """Normalize array to zero mean and unit variance."""
+        arr = np.array(arr, dtype=np.float64)
+        std = arr.std()
+        if std == 0:
+            return np.zeros_like(arr)
+        return (arr - arr.mean()) / std
+
+    def compute_grpo_advantages(rewards):
+        """GRPO: aggregate first, then normalize."""
+        totals = rewards.sum(axis=1)
+        return normalize(totals)
+
+    def compute_gdpo_advantages(rewards):
+        """GDPO: normalize each dimension, then sum."""
+        advantages = np.zeros(len(rewards))
+        for dim in range(rewards.shape[1]):
+            advantages += normalize(rewards[:, dim])
+        return advantages
+
+    def train_policy(method, epochs=100, lr=0.1, batch_size=32, seed=41, fixed_rewards=None):
+        """Train a 3-dimensional Bernoulli policy using GRPO or GDPO.
+
+        Args:
+            fixed_rewards: If provided (numpy array), use this fixed dataset every epoch.
+                           If None, sample fresh data each epoch (default).
+
+        Returns history of probabilities over epochs.
+        """
+        rng = np.random.default_rng(seed)
+
+        # Policy parameters (log-odds, initialized to 0 -> prob 0.5)
+        logits = np.zeros(3)
+
+        history = []
+
+        for _epoch in range(epochs):
+            # Current probabilities
+            probs = 1 / (1 + np.exp(-logits))
+            history.append(probs.copy())
+
+            # Get rewards: either fixed or freshly sampled
+            if fixed_rewards is not None:
+                rewards = fixed_rewards
+            else:
+                rewards = (rng.random((batch_size, 3)) < probs).astype(np.float64)
+
+            # Compute advantages
+            if method == 'grpo':
+                advantages = compute_grpo_advantages(rewards)
+            else:
+                advantages = compute_gdpo_advantages(rewards)
+
+            # Policy gradient update
+            # grad log p(a) * advantage, where p(a) = prod of Bernoulli probs
+            for i in range(3):
+                # For Bernoulli: grad log p = (reward - prob) for that dimension
+                grad = ((rewards[:, i] - probs[i]) * advantages).mean()
+                logits[i] += lr * grad
+
+        return np.array(history)
+    return (train_policy,)
+
+
+@app.cell
+def _(mo):
+    reuse_toggle = mo.ui.switch(label="Train on widget data (instead of fresh samples each epoch)")
+    reuse_toggle
+    return (reuse_toggle,)
+
+
+@app.cell
+def _():
+    import numpy as _np
+
+    def widget_rewards_to_array(rewards_list):
+        """Convert widget rewards list to numpy array."""
+        return _np.array([
+            [r["correctness"], r["style"], r["conciseness"]]
+            for r in rewards_list
+        ], dtype=_np.float64)
+    return (widget_rewards_to_array,)
+
+
+@app.cell
+def _(reuse_toggle, train_policy, widget_rewards_to_array, widget_view):
+    if reuse_toggle.value:
+        fixed = widget_rewards_to_array(widget_view.widget.rewards)
+    else:
+        fixed = None
+    grpo_history = train_policy('grpo', epochs=150, lr=0.15, fixed_rewards=fixed)
+    gdpo_history = train_policy('gdpo', epochs=150, lr=0.15, fixed_rewards=fixed)
+    return gdpo_history, grpo_history
+
+
+@app.cell
+def _(gdpo_history, grpo_history):
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+
+    colors = ['#1f77b4', '#ff7f0e', '#2ca02c']  # blue, orange, green
+    labels = ['correctness', 'style', 'conciseness']
+    epochs = range(len(grpo_history))
+
+    # Plot GDPO (solid) first, then GRPO (dotted) on top so dotted is visible
+    for i, (color, label) in enumerate(zip(colors, labels)):
+        ax.plot(epochs, gdpo_history[:, i], '-', color=color, linewidth=2,
+                label=f'{label} (GDPO)')
+    for i, (color, label) in enumerate(zip(colors, labels)):
+        ax.plot(epochs, grpo_history[:, i], '--', color=color, linewidth=2,
+                label=f'{label} (GRPO)')
+
+    ax.set_xlabel('Epoch')
+    ax.set_ylabel('Probability')
+    ax.set_title('GRPO vs GDPO Convergence: Policy Probabilities Over Training')
+    ax.set_ylim(0, 1.05)
+    ax.legend(loc='lower right', ncol=2)
+    ax.grid(True, alpha=0.3)
+
+    fig
     return
 
 

--- a/grpo_gdpo_widget/widget.css
+++ b/grpo_gdpo_widget/widget.css
@@ -1,0 +1,145 @@
+.grpo-gdpo-root {
+  --bg-primary: #ffffff;
+  --bg-secondary: #f5f5f5;
+  --bg-hover: #e8e8e8;
+  --text-primary: #1a1a1a;
+  --text-secondary: #666666;
+  --border-color: #ddd;
+  --accent-color: #4a9eff;
+  --diff-positive: #22c55e;
+  --diff-negative: #ef4444;
+  --cell-active: #3b82f6;
+  --cell-inactive: #94a3b8;
+
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  padding: 1rem;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border-radius: 8px;
+}
+
+/* Dark mode support */
+@media (prefers-color-scheme: dark) {
+  .grpo-gdpo-root {
+    --bg-primary: #1e1e1e;
+    --bg-secondary: #2d2d2d;
+    --bg-hover: #3d3d3d;
+    --text-primary: #e0e0e0;
+    --text-secondary: #a0a0a0;
+    --border-color: #444;
+    --accent-color: #60a5fa;
+    --diff-positive: #4ade80;
+    --diff-negative: #f87171;
+    --cell-active: #60a5fa;
+    --cell-inactive: #64748b;
+  }
+}
+
+/* Marimo dark mode class support */
+.dark .grpo-gdpo-root,
+[data-theme="dark"] .grpo-gdpo-root {
+  --bg-primary: #1e1e1e;
+  --bg-secondary: #2d2d2d;
+  --bg-hover: #3d3d3d;
+  --text-primary: #e0e0e0;
+  --text-secondary: #a0a0a0;
+  --border-color: #444;
+  --accent-color: #60a5fa;
+  --diff-positive: #4ade80;
+  --diff-negative: #f87171;
+  --cell-active: #60a5fa;
+  --cell-inactive: #64748b;
+}
+
+.grpo-gdpo-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+.grpo-gdpo-table th,
+.grpo-gdpo-table td {
+  padding: 0.6rem 0.8rem;
+  text-align: center;
+  border: 1px solid var(--border-color);
+}
+
+.grpo-gdpo-table th {
+  background: var(--bg-secondary);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.grpo-gdpo-table tbody tr:hover {
+  background: var(--bg-hover);
+}
+
+.rollout-label {
+  font-weight: 500;
+  text-align: left !important;
+  color: var(--text-secondary);
+}
+
+.reward-cell {
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 1rem;
+  transition: all 0.15s ease;
+  user-select: none;
+}
+
+.reward-cell:hover {
+  background: var(--bg-hover);
+  transform: scale(1.05);
+}
+
+.reward-cell[data-value="1"] {
+  color: var(--cell-active);
+}
+
+.reward-cell[data-value="0"] {
+  color: var(--cell-inactive);
+}
+
+.computed-cell {
+  font-family: "SF Mono", "Consolas", monospace;
+  color: var(--text-secondary);
+}
+
+.diff-cell {
+  font-family: "SF Mono", "Consolas", monospace;
+  font-weight: 500;
+}
+
+.diff-cell.has-diff {
+  color: var(--diff-positive);
+  background: rgba(34, 197, 94, 0.1);
+}
+
+.button-row {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.action-btn {
+  padding: 0.4rem 0.8rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.action-btn:hover:not(:disabled) {
+  background: var(--bg-hover);
+  border-color: var(--accent-color);
+}
+
+.action-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/grpo_gdpo_widget/widget.js
+++ b/grpo_gdpo_widget/widget.js
@@ -1,0 +1,196 @@
+function render({ model, el }) {
+  const container = document.createElement("div");
+  container.className = "grpo-gdpo-root";
+  el.appendChild(container);
+
+  // Helper functions for statistics
+  function mean(arr) {
+    if (arr.length === 0) return 0;
+    return arr.reduce((a, b) => a + b, 0) / arr.length;
+  }
+
+  function std(arr) {
+    if (arr.length <= 1) return 0;
+    const m = mean(arr);
+    // Use sample std (n-1) to match the paper
+    const variance = arr.reduce((acc, val) => acc + (val - m) ** 2, 0) / (arr.length - 1);
+    return Math.sqrt(variance);
+  }
+
+  function normalize(arr) {
+    const m = mean(arr);
+    const s = std(arr);
+    if (s === 0) return arr.map(() => 0);
+    return arr.map((v) => (v - m) / s);
+  }
+
+  // Calculate GRPO advantage (normalize total reward)
+  function calcGrpoAdvantages(rewards) {
+    const totals = rewards.map(
+      (r) => r.correctness + r.style + r.conciseness
+    );
+    return normalize(totals);
+  }
+
+  // Calculate GDPO advantage (normalize each dimension, then sum)
+  function calcGdpoAdvantages(rewards) {
+    const correctness = rewards.map((r) => r.correctness);
+    const style = rewards.map((r) => r.style);
+    const conciseness = rewards.map((r) => r.conciseness);
+
+    const normCorrectness = normalize(correctness);
+    const normStyle = normalize(style);
+    const normConciseness = normalize(conciseness);
+
+    return rewards.map(
+      (_, i) => normCorrectness[i] + normStyle[i] + normConciseness[i]
+    );
+  }
+
+  function formatNumber(n) {
+    if (n === 0) return "0.000";
+    return n.toFixed(3);
+  }
+
+  function draw() {
+    const rewards = model.get("rewards") || [];
+
+    const grpoAdvantages = calcGrpoAdvantages(rewards);
+    const gdpoAdvantages = calcGdpoAdvantages(rewards);
+
+    container.innerHTML = "";
+
+    // Create table
+    const table = document.createElement("table");
+    table.className = "grpo-gdpo-table";
+
+    // Header row
+    const thead = document.createElement("thead");
+    const headerRow = document.createElement("tr");
+    const headers = [
+      "",
+      "Correctness",
+      "Style",
+      "Conciseness",
+      "Total",
+      "GRPO Adv",
+      "GDPO Adv",
+      "Difference",
+    ];
+    headers.forEach((h) => {
+      const th = document.createElement("th");
+      th.textContent = h;
+      headerRow.appendChild(th);
+    });
+    thead.appendChild(headerRow);
+    table.appendChild(thead);
+
+    // Body rows
+    const tbody = document.createElement("tbody");
+    rewards.forEach((reward, rowIndex) => {
+      const row = document.createElement("tr");
+
+      // Rollout label
+      const labelCell = document.createElement("td");
+      labelCell.className = "rollout-label";
+      labelCell.textContent = `Rollout ${rowIndex}`;
+      row.appendChild(labelCell);
+
+      // Reward cells (clickable)
+      ["correctness", "style", "conciseness"].forEach((dim) => {
+        const cell = document.createElement("td");
+        cell.className = "reward-cell";
+        cell.dataset.value = reward[dim];
+        cell.textContent = reward[dim];
+        cell.addEventListener("click", () => {
+          const newRewards = [...rewards];
+          newRewards[rowIndex] = {
+            ...newRewards[rowIndex],
+            [dim]: reward[dim] === 1 ? 0 : 1,
+          };
+          model.set("rewards", newRewards);
+          model.save_changes();
+        });
+        row.appendChild(cell);
+      });
+
+      // Total
+      const total = reward.correctness + reward.style + reward.conciseness;
+      const totalCell = document.createElement("td");
+      totalCell.className = "computed-cell";
+      totalCell.textContent = total;
+      row.appendChild(totalCell);
+
+      // GRPO Advantage
+      const grpoCell = document.createElement("td");
+      grpoCell.className = "computed-cell";
+      grpoCell.textContent = formatNumber(grpoAdvantages[rowIndex]);
+      row.appendChild(grpoCell);
+
+      // GDPO Advantage
+      const gdpoCell = document.createElement("td");
+      gdpoCell.className = "computed-cell";
+      gdpoCell.textContent = formatNumber(gdpoAdvantages[rowIndex]);
+      row.appendChild(gdpoCell);
+
+      // Difference
+      const diff = gdpoAdvantages[rowIndex] - grpoAdvantages[rowIndex];
+      const diffCell = document.createElement("td");
+      diffCell.className = "diff-cell";
+      if (Math.abs(diff) > 0.001) {
+        diffCell.classList.add("has-diff");
+      }
+      diffCell.textContent = formatNumber(diff);
+      row.appendChild(diffCell);
+
+      tbody.appendChild(row);
+    });
+    table.appendChild(tbody);
+
+    container.appendChild(table);
+
+    // Add/Remove buttons
+    const buttonRow = document.createElement("div");
+    buttonRow.className = "button-row";
+
+    const addBtn = document.createElement("button");
+    addBtn.textContent = "+ Add Rollout";
+    addBtn.className = "action-btn";
+    addBtn.addEventListener("click", () => {
+      const newRewards = [
+        ...rewards,
+        { correctness: 0, style: 0, conciseness: 0 },
+      ];
+      model.set("rewards", newRewards);
+      model.save_changes();
+    });
+    buttonRow.appendChild(addBtn);
+
+    const removeBtn = document.createElement("button");
+    removeBtn.textContent = "- Remove Last";
+    removeBtn.className = "action-btn";
+    removeBtn.disabled = rewards.length <= 2;
+    removeBtn.addEventListener("click", () => {
+      if (rewards.length > 2) {
+        const newRewards = rewards.slice(0, -1);
+        model.set("rewards", newRewards);
+        model.save_changes();
+      }
+    });
+    buttonRow.appendChild(removeBtn);
+
+    container.appendChild(buttonRow);
+  }
+
+  // Listen for changes
+  model.on("change:rewards", draw);
+
+  // Initial render
+  draw();
+
+  return () => {
+    // Cleanup
+  };
+}
+
+export default { render };

--- a/grpo_gdpo_widget/widget.py
+++ b/grpo_gdpo_widget/widget.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import anywidget
+import traitlets
+
+
+_ASSET_DIR = Path(__file__).parent
+_JS_SOURCE = (_ASSET_DIR / "widget.js").read_text()
+_CSS_SOURCE = (_ASSET_DIR / "widget.css").read_text()
+
+
+class GrpoGdpoWidget(anywidget.AnyWidget):
+    """Interactive widget for comparing GRPO vs GDPO advantage calculations.
+
+    Allows users to toggle binary rewards (correctness, style, conciseness)
+    and see how the two normalization approaches differ.
+    """
+    _esm = _JS_SOURCE
+    _css = _CSS_SOURCE
+
+    rewards = traitlets.List(
+        traitlets.Dict(),
+        default_value=[
+            {"correctness": 1, "style": 0, "conciseness": 0},
+            {"correctness": 1, "style": 0, "conciseness": 1},
+            {"correctness": 0, "style": 1, "conciseness": 1},
+            {"correctness": 0, "style": 1, "conciseness": 1},
+            {"correctness": 1, "style": 0, "conciseness": 0},
+            {"correctness": 0, "style": 1, "conciseness": 0},
+        ]
+    ).tag(sync=True)
+
+    def add_rollout(self):
+        """Add a new rollout with default values."""
+        self.rewards = self.rewards + [{"correctness": 0, "style": 0, "conciseness": 0}]
+
+    def remove_rollout(self, index=-1):
+        """Remove a rollout by index (default: last)."""
+        if len(self.rewards) > 2:
+            rewards = list(self.rewards)
+            rewards.pop(index)
+            self.rewards = rewards


### PR DESCRIPTION
## Summary

Added an interactive anywidget-based marimo notebook that visualizes the difference between GRPO (Group Relative Policy Optimization) and GDPO (Group reward-Decoupled Normalization Policy Optimization) algorithms from the research paper. Users can toggle binary reward values and observe how each algorithm normalizes and calculates advantages differently.

## Features

- Interactive table with clickable reward cells (correctness, style, conciseness)
- Real-time calculation of GRPO and GDPO advantages with sample standard deviation
- Visual highlighting of differences between the two approaches
- Dark mode support with CSS custom properties
- Add/remove rollout functionality
- Verification matches paper's Seed 1 and Seed 2 examples

🤖 Generated with Claude Code