### PR TITLE
Refine cube widget: transparent edges, light mode, z-order

### DIFF
--- a/cube_demo.py
+++ b/cube_demo.py
@@ -229,12 +229,6 @@ def _(calculate_trajectory, cube_view, np, plt):
 
 
 @app.cell
-def _(cube_view):
-    cube_view.value["plane"]
-    return
-
-
-@app.cell
 def _(cube_view, mo, trajectory_chart):
     mo.hstack([cube_view, trajectory_chart], justify="start", gap=1)
     return

--- a/cube_widget/cube_widget.css
+++ b/cube_widget/cube_widget.css
@@ -1,41 +1,30 @@
+/* Root container - light mode by default */
 .cube-widget-root {
-  --color-plane: #3498db;
-  --color-line: #e67e22;
-  --color-point: #27ae60;
-  --color-bg: #ffffff;
-  --color-text: #333;
+  --color-bg: #fff;
+  --color-text: #444;
+  --color-text-muted: #888;
   --color-border: #e0e0e0;
-  --color-control-bg: #f5f5f5;
-}
+  --color-surface: #f8f8f8;
+  --color-wireframe: #bbb;
 
-@media (prefers-color-scheme: dark) {
-  .cube-widget-root {
-    --color-bg: #1e1e1e;
-    --color-text: #e0e0e0;
-    --color-border: #444;
-    --color-control-bg: #2a2a2a;
-  }
-}
-
-.dark .cube-widget-root,
-[data-theme="dark"] .cube-widget-root {
-  --color-bg: #1e1e1e;
-  --color-text: #e0e0e0;
-  --color-border: #444;
-  --color-control-bg: #2a2a2a;
-}
-
-.cube-widget-root {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding: 1rem;
+  padding: 1.25rem;
   background: var(--color-bg);
-  border: 1px solid var(--color-border);
-  border-radius: 12px;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   color: var(--color-text);
-  max-width: 500px;
+  max-width: 420px;
+}
+
+/* Dark mode - class added by JS theme detection */
+.cube-widget-root.dark-mode {
+  --color-bg: #1a1a1a;
+  --color-text: #e0e0e0;
+  --color-text-muted: #888;
+  --color-border: #333;
+  --color-surface: #242424;
+  --color-wireframe: #555;
 }
 
 .cube-container {
@@ -44,20 +33,15 @@
   gap: 1rem;
 }
 
+/* SVG container */
 .svg-container {
   width: 100%;
   aspect-ratio: 1.1;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, #fafafa 0%, #f0f0f0 100%);
-  border-radius: 8px;
+  background: var(--color-surface);
   overflow: hidden;
-}
-
-.dark .svg-container,
-[data-theme="dark"] .svg-container {
-  background: linear-gradient(135deg, #2a2a2a 0%, #1e1e1e 100%);
 }
 
 .cube-svg {
@@ -65,17 +49,17 @@
   height: 100%;
 }
 
-/* Axis labels in SVG */
+/* Axis labels */
 .axis {
   cursor: pointer;
 }
 
 .axis:hover .axis-label-bg {
-  filter: brightness(1.1);
+  filter: brightness(1.08);
 }
 
 .axis-label-bg {
-  transition: filter 0.15s ease, transform 0.15s ease;
+  transition: filter 0.15s ease;
 }
 
 .axis-label-text {
@@ -100,22 +84,20 @@
 .cube-controls {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  padding: 0.75rem;
+  gap: 0.75rem;
 }
 
 .state-display {
-  font-size: 12px;
-  color: var(--color-text);
-  opacity: 0.6;
+  font-size: 11px;
+  color: var(--color-text-muted);
   text-align: center;
-  padding: 4px;
+  letter-spacing: 0.02em;
 }
 
 .sliders-container {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
 }
 
 .sliders-container:empty {
@@ -129,70 +111,65 @@
 }
 
 .slider-label {
-  font-weight: 600;
-  font-size: 13px;
-  min-width: 80px;
+  font-weight: 500;
+  font-size: 12px;
+  min-width: 70px;
+  letter-spacing: 0.01em;
 }
 
 .axis-slider {
   flex: 1;
-  height: 6px;
+  height: 4px;
   cursor: pointer;
   -webkit-appearance: none;
   appearance: none;
-  background: rgba(0, 0, 0, 0.1);
-  border-radius: 3px;
-}
-
-.dark .axis-slider,
-[data-theme="dark"] .axis-slider {
-  background: rgba(255, 255, 255, 0.15);
+  background: var(--color-border);
+  border-radius: 2px;
 }
 
 .axis-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   border-radius: 50%;
   background: currentColor;
   cursor: pointer;
-  border: 2px solid white;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  border: 2px solid var(--color-bg);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.15);
 }
 
 .axis-slider::-moz-range-thumb {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   border-radius: 50%;
   background: currentColor;
   cursor: pointer;
-  border: 2px solid white;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  border: 2px solid var(--color-bg);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.15);
 }
 
 .slider-value {
-  font-family: monospace;
-  font-size: 12px;
-  min-width: 40px;
+  font-family: "SF Mono", Menlo, Monaco, monospace;
+  font-size: 11px;
+  min-width: 36px;
   text-align: right;
-  color: var(--color-text);
-  opacity: 0.7;
+  color: var(--color-text-muted);
 }
 
 .reset-button {
-  padding: 6px 14px;
+  padding: 5px 12px;
   background: transparent;
-  color: var(--color-text);
+  color: var(--color-text-muted);
   border: 1px solid var(--color-border);
-  border-radius: 4px;
-  font-size: 12px;
+  border-radius: 3px;
+  font-size: 11px;
+  letter-spacing: 0.02em;
   cursor: pointer;
   transition: all 0.15s;
   align-self: center;
-  opacity: 0.6;
 }
 
 .reset-button:hover {
-  opacity: 1;
-  border-color: var(--color-text);
+  color: var(--color-text);
+  border-color: var(--color-text-muted);
 }


### PR DESCRIPTION
Improves the cube widget with three key refinements:

- **Transparent front edges**: The three edges meeting at the front corner (v2) are now transparent so you can see inside the cube
- **Light mode by default**: Removed `prefers-color-scheme` media query; widget defaults to light and uses JavaScript to detect dark theme from parent document
- **Better layering**: Axes now draw behind selection geometry (plane/line/point) for improved visual clarity

Styling is cleaner and more minimal with flat colors, subtle typography, and refined spacing throughout.