### PR TITLE
Add Sushi Go genetic algorithm with neural network agents

### DIFF
--- a/sushigo/__init__.py
+++ b/sushigo/__init__.py
@@ -1,0 +1,13 @@
+from game import SushiGoGame, CARD_NAMES, NUM_CARD_TYPES
+from agent import NeuralAgent, RandomAgent, CHROMOSOME_SIZE
+from ga import GeneticAlgorithm
+
+__all__ = [
+    "SushiGoGame",
+    "CARD_NAMES",
+    "NUM_CARD_TYPES",
+    "NeuralAgent",
+    "RandomAgent",
+    "CHROMOSOME_SIZE",
+    "GeneticAlgorithm",
+]

--- a/sushigo/agent.py
+++ b/sushigo/agent.py
@@ -1,0 +1,118 @@
+"""Neural network agent for Sushi Go."""
+
+import numpy as np
+from game import NUM_CARD_TYPES
+
+INPUT_SIZE = 37  # 11 + 1 + 11 + 11 + 1 + 1 + 1
+HIDDEN_SIZE = 16
+OUTPUT_SIZE = NUM_CARD_TYPES  # 11
+
+# Weight layout in flat chromosome
+_W1_SIZE = INPUT_SIZE * HIDDEN_SIZE   # 592
+_B1_SIZE = HIDDEN_SIZE                # 16
+_W2_SIZE = HIDDEN_SIZE * OUTPUT_SIZE  # 176
+_B2_SIZE = OUTPUT_SIZE                # 11
+CHROMOSOME_SIZE = _W1_SIZE + _B1_SIZE + _W2_SIZE + _B2_SIZE  # 795
+
+
+def _build_features(state: dict) -> np.ndarray:
+    """Build a (37,) feature vector from game state dict."""
+    features = np.zeros(INPUT_SIZE, dtype=np.float64)
+    i = 0
+    # My collected cards (11)
+    features[i:i + NUM_CARD_TYPES] = state["my_collected"]
+    i += NUM_CARD_TYPES
+    # My unused wasabi (1)
+    features[i] = state["my_unused_wasabi"]
+    i += 1
+    # Hand cards (11)
+    features[i:i + NUM_CARD_TYPES] = state["hand"]
+    i += NUM_CARD_TYPES
+    # Opponent collected (11)
+    features[i:i + NUM_CARD_TYPES] = state["opp_collected"]
+    i += NUM_CARD_TYPES
+    # Opponent unused wasabi (1)
+    features[i] = state["opp_unused_wasabi"]
+    i += 1
+    # Round number normalized (1)
+    features[i] = state["round"] / 2.0
+    i += 1
+    # Cards remaining normalized (1)
+    features[i] = state["cards_remaining"] / 10.0
+    return features
+
+
+class NeuralAgent:
+    """Agent whose strategy is a small feedforward neural network."""
+
+    def __init__(self, weights: np.ndarray | None = None, rng: np.random.Generator | None = None):
+        self.rng = rng or np.random.default_rng()
+        if weights is None:
+            # Xavier initialization
+            self._weights = self.rng.standard_normal(CHROMOSOME_SIZE).astype(np.float64) * 0.1
+        else:
+            self._weights = weights.copy().astype(np.float64)
+        self._unpack()
+
+    def _unpack(self):
+        """Unpack flat weight vector into matrices."""
+        idx = 0
+        self.W1 = self._weights[idx:idx + _W1_SIZE].reshape(INPUT_SIZE, HIDDEN_SIZE)
+        idx += _W1_SIZE
+        self.b1 = self._weights[idx:idx + _B1_SIZE]
+        idx += _B1_SIZE
+        self.W2 = self._weights[idx:idx + _W2_SIZE].reshape(HIDDEN_SIZE, OUTPUT_SIZE)
+        idx += _W2_SIZE
+        self.b2 = self._weights[idx:idx + _B2_SIZE]
+
+    @property
+    def chromosome(self) -> np.ndarray:
+        return self._weights.copy()
+
+    def forward(self, x: np.ndarray) -> np.ndarray:
+        """Forward pass: input (37,) -> output (11,)."""
+        h = np.maximum(0, x @ self.W1 + self.b1)  # ReLU
+        return h @ self.W2 + self.b2
+
+    def pick_card(self, state: dict) -> int:
+        """Pick a card type given the game state. Returns a card type int."""
+        x = _build_features(state)
+        scores = self.forward(x)
+        hand = state["hand"]
+        # Mask unavailable card types
+        mask = hand > 0
+        scores[~mask] = -np.inf
+        return int(np.argmax(scores))
+
+    @staticmethod
+    def crossover(parent1: "NeuralAgent", parent2: "NeuralAgent",
+                  rng: np.random.Generator | None = None) -> "NeuralAgent":
+        """Single-point crossover on flat weight vectors."""
+        rng = rng or np.random.default_rng()
+        point = rng.integers(1, CHROMOSOME_SIZE)
+        child_weights = np.concatenate([
+            parent1.chromosome[:point],
+            parent2.chromosome[point:],
+        ])
+        return NeuralAgent(weights=child_weights, rng=rng)
+
+    def mutate(self, rate: float = 0.1, sigma: float = 0.3,
+               rng: np.random.Generator | None = None) -> "NeuralAgent":
+        """Return a mutated copy. Each weight is perturbed with probability `rate`."""
+        rng = rng or self.rng
+        new_weights = self.chromosome
+        mask = rng.random(CHROMOSOME_SIZE) < rate
+        new_weights[mask] += rng.normal(0, sigma, size=mask.sum())
+        return NeuralAgent(weights=new_weights, rng=rng)
+
+
+class RandomAgent:
+    """Baseline agent that picks a random card from the hand."""
+
+    def __init__(self, rng: np.random.Generator | None = None):
+        self.rng = rng or np.random.default_rng()
+
+    def pick_card(self, state: dict) -> int:
+        hand = state["hand"]
+        available = np.where(hand > 0)[0]
+        return int(self.rng.choice(available))

--- a/sushigo/demo.py
+++ b/sushigo/demo.py
@@ -1,0 +1,264 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "marimo",
+#     "numpy",
+#     "altair",
+#     "polars",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.20.1"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    import numpy as np
+    import altair as alt
+    import polars as pl
+
+    return alt, mo, np, pl
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    # Sushi Go: Evolving Neural Network Players
+
+    This notebook evolves [Sushi Go](https://boardgamegeek.com/boardgame/133473/sushi-go) players
+    using a **genetic algorithm**. Each agent's strategy is a small feedforward neural network
+    (37 inputs → 16 hidden → 11 outputs = **795 weights**).
+
+    The input features capture: cards collected so far, what's in the current hand, opponent's
+    visible cards, wasabi state, round number, and cards remaining. The output is a preference
+    score for each card type — the agent picks the highest-scoring available card.
+
+    The GA evolves these weight vectors through tournament selection, crossover, and mutation.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    pop_size = mo.ui.slider(20, 200, value=80, step=10, label="Population size")
+    generations = mo.ui.slider(10, 200, value=50, step=10, label="Generations")
+    mutation_rate = mo.ui.slider(0.01, 0.5, value=0.1, step=0.01, label="Mutation rate")
+    mutation_sigma = mo.ui.slider(0.05, 1.0, value=0.3, step=0.05, label="Mutation sigma")
+    games_per_eval = mo.ui.slider(5, 50, value=20, step=5, label="Games per evaluation")
+    seed_input = mo.ui.number(value=42, start=0, stop=9999, label="Random seed")
+
+    controls = mo.vstack([
+        mo.md("## Settings"),
+        mo.hstack([pop_size, generations, seed_input], justify="start"),
+        mo.hstack([mutation_rate, mutation_sigma, games_per_eval], justify="start"),
+    ])
+    controls
+    return (
+        games_per_eval,
+        generations,
+        mutation_rate,
+        mutation_sigma,
+        pop_size,
+        seed_input,
+    )
+
+
+@app.cell
+def _(generations, mo, pop_size, seed_input):
+    run_btn = mo.ui.run_button(label="Evolve!")
+    mo.hstack([
+        run_btn,
+        mo.md(f"Will run **{generations.value}** generations with **{pop_size.value}** agents "
+              f"(seed={seed_input.value})"),
+    ], justify="start")
+    return (run_btn,)
+
+
+@app.cell
+def _(
+    games_per_eval,
+    generations,
+    mo,
+    mutation_rate,
+    mutation_sigma,
+    pop_size,
+    run_btn,
+    seed_input,
+):
+    mo.stop(not run_btn.value, mo.md("*Click 'Evolve!' to start the genetic algorithm.*"))
+
+    from ga import GeneticAlgorithm
+
+    ga = GeneticAlgorithm(
+        pop_size=pop_size.value,
+        elite_count=max(1, pop_size.value // 20),
+        tournament_k=3,
+        mutation_rate=mutation_rate.value,
+        mutation_sigma=mutation_sigma.value,
+        games_per_eval=games_per_eval.value,
+        seed=seed_input.value,
+    )
+    result = ga.run(generations=generations.value)
+    best_agent = result["best_agent"]
+    history = result["history"]
+    result
+    return best_agent, history
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## Fitness Over Generations
+    """)
+    return
+
+
+@app.cell
+def _(alt, history, pl):
+    df = pl.DataFrame({
+        "generation": history["generation"],
+        "best": history["best"],
+        "mean": history["mean"],
+        "worst": history["worst"],
+    }).unpivot(
+        index="generation",
+        on=["best", "mean", "worst"],
+        variable_name="metric",
+        value_name="fitness",
+    )
+
+    chart = (
+        alt.Chart(df)
+        .mark_line()
+        .encode(
+            x=alt.X("generation:Q", title="Generation"),
+            y=alt.Y("fitness:Q", title="Win rate vs random agent"),
+            color=alt.Color("metric:N", title="Metric"),
+        )
+        .properties(width=600, height=350)
+    )
+    chart
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Best Agent vs Random Agent
+
+    Let's play some games between the evolved best agent and a random baseline to see how much the GA learned.
+    """)
+    return
+
+
+@app.cell
+def _(best_agent, mo, np, pl):
+    from game import SushiGoGame
+    from agent import RandomAgent
+
+    rng = np.random.default_rng(0)
+    game = SushiGoGame(rng=rng)
+    random_agent = RandomAgent(rng=rng)
+
+    n_games = 100
+    wins, losses, draws = 0, 0, 0
+    score_diffs = []
+    for _ in range(n_games):
+        s1, s2 = game.play(best_agent, random_agent)
+        score_diffs.append(s1 - s2)
+        if s1 > s2:
+            wins += 1
+        elif s1 < s2:
+            losses += 1
+        else:
+            draws += 1
+
+    summary_df = pl.DataFrame({
+        "Result": ["Wins", "Losses", "Draws"],
+        "Count": [wins, losses, draws],
+        "Percentage": [f"{100*wins/n_games:.0f}%", f"{100*losses/n_games:.0f}%", f"{100*draws/n_games:.0f}%"],
+    })
+
+    mo.vstack([
+        mo.md(f"Over **{n_games}** games against a random agent:"),
+        summary_df,
+        mo.md(f"Average score difference: **{np.mean(score_diffs):.1f}** points"),
+    ])
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Agent Card Preferences
+
+    What does the evolved agent prefer to pick in different situations?
+    Below we show the neural network's raw output scores for each card type given a few
+    representative board states (empty board at start, and with some cards already collected).
+    """)
+    return
+
+
+@app.cell
+def _(alt, best_agent, np, pl):
+    from game import CARD_NAMES, NUM_CARD_TYPES
+
+    def _get_preferences(agent, collected=None, hand=None, round_num=0, cards_remaining=10):
+        """Get raw preference scores from the agent's NN for a given state."""
+        if collected is None:
+            collected = np.zeros(NUM_CARD_TYPES, dtype=np.int32)
+        if hand is None:
+            hand = np.ones(NUM_CARD_TYPES, dtype=np.int32)
+        state = {
+            "my_collected": collected,
+            "my_unused_wasabi": 0,
+            "hand": hand,
+            "opp_collected": np.zeros(NUM_CARD_TYPES, dtype=np.int32),
+            "opp_unused_wasabi": 0,
+            "round": round_num,
+            "cards_remaining": cards_remaining,
+        }
+        from agent import _build_features
+        x = _build_features(state)
+        return agent.forward(x)
+
+    # Scenario 1: Empty board, all cards available
+    scores_empty = _get_preferences(best_agent)
+    # Scenario 2: Have 1 tempura already
+    collected_1t = np.zeros(NUM_CARD_TYPES, dtype=np.int32)
+    collected_1t[6] = 1  # TEMPURA
+    scores_1tempura = _get_preferences(best_agent, collected=collected_1t)
+    # Scenario 3: Have 2 sashimi already
+    collected_2s = np.zeros(NUM_CARD_TYPES, dtype=np.int32)
+    collected_2s[7] = 2  # SASHIMI
+    scores_2sashimi = _get_preferences(best_agent, collected=collected_2s)
+
+    pref_df = pl.DataFrame({
+        "card": CARD_NAMES * 3,
+        "score": list(scores_empty) + list(scores_1tempura) + list(scores_2sashimi),
+        "scenario": (["Empty board"] * NUM_CARD_TYPES
+                     + ["Has 1 Tempura"] * NUM_CARD_TYPES
+                     + ["Has 2 Sashimi"] * NUM_CARD_TYPES),
+    })
+
+    pref_chart = (
+        alt.Chart(pref_df)
+        .mark_bar()
+        .encode(
+            x=alt.X("card:N", title="Card Type", sort=CARD_NAMES),
+            y=alt.Y("score:Q", title="Preference Score"),
+            color=alt.Color("scenario:N", title="Scenario"),
+            xOffset="scenario:N",
+        )
+        .properties(width=650, height=350)
+    )
+    pref_chart
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/sushigo/ga.py
+++ b/sushigo/ga.py
@@ -1,0 +1,98 @@
+"""Genetic algorithm for evolving Sushi Go agents."""
+
+import numpy as np
+from game import SushiGoGame
+from agent import NeuralAgent, RandomAgent
+
+
+class GeneticAlgorithm:
+    def __init__(
+        self,
+        pop_size: int = 100,
+        elite_count: int = 5,
+        tournament_k: int = 3,
+        mutation_rate: float = 0.1,
+        mutation_sigma: float = 0.3,
+        games_per_eval: int = 20,
+        seed: int | None = None,
+    ):
+        self.pop_size = pop_size
+        self.elite_count = elite_count
+        self.tournament_k = tournament_k
+        self.mutation_rate = mutation_rate
+        self.mutation_sigma = mutation_sigma
+        self.games_per_eval = games_per_eval
+        self.rng = np.random.default_rng(seed)
+
+    def _make_population(self) -> list[NeuralAgent]:
+        return [NeuralAgent(rng=self.rng) for _ in range(self.pop_size)]
+
+    def evaluate_fitness(self, population: list[NeuralAgent]) -> np.ndarray:
+        """Evaluate each agent by win rate against a random agent.
+        Fitness = (wins + 0.5 * draws) / games_per_eval, i.e. a value in [0, 1]."""
+        fitness = np.zeros(len(population))
+        game = SushiGoGame(rng=self.rng)
+        random_opponent = RandomAgent(rng=self.rng)
+
+        for i, agent in enumerate(population):
+            wins = 0.0
+            for _ in range(self.games_per_eval):
+                s1, s2 = game.play(agent, random_opponent)
+                if s1 > s2:
+                    wins += 1.0
+                elif s1 == s2:
+                    wins += 0.5
+            fitness[i] = wins / self.games_per_eval
+        return fitness
+
+    def _tournament_select(self, population: list[NeuralAgent], fitness: np.ndarray) -> NeuralAgent:
+        """Select one agent via tournament selection."""
+        indices = self.rng.choice(len(population), size=self.tournament_k, replace=False)
+        best = indices[np.argmax(fitness[indices])]
+        return population[best]
+
+    def evolve_step(self, population: list[NeuralAgent], fitness: np.ndarray) -> list[NeuralAgent]:
+        """Produce next generation via elitism + tournament selection + crossover + mutation."""
+        # Elitism: keep top agents
+        elite_indices = np.argsort(fitness)[-self.elite_count:]
+        new_pop = [NeuralAgent(weights=population[i].chromosome, rng=self.rng) for i in elite_indices]
+
+        # Fill remaining slots
+        while len(new_pop) < self.pop_size:
+            parent1 = self._tournament_select(population, fitness)
+            parent2 = self._tournament_select(population, fitness)
+            child = NeuralAgent.crossover(parent1, parent2, rng=self.rng)
+            child = child.mutate(rate=self.mutation_rate, sigma=self.mutation_sigma, rng=self.rng)
+            new_pop.append(child)
+
+        return new_pop
+
+    def run(self, generations: int = 50) -> dict:
+        """Run the full evolution loop. Returns history dict."""
+        population = self._make_population()
+        history = {"best": [], "mean": [], "worst": [], "generation": []}
+
+        for gen in range(generations):
+            fitness = self.evaluate_fitness(population)
+
+            history["generation"].append(gen)
+            history["best"].append(float(np.max(fitness)))
+            history["mean"].append(float(np.mean(fitness)))
+            history["worst"].append(float(np.min(fitness)))
+
+            population = self.evolve_step(population, fitness)
+
+        # Final evaluation
+        fitness = self.evaluate_fitness(population)
+        history["generation"].append(generations)
+        history["best"].append(float(np.max(fitness)))
+        history["mean"].append(float(np.mean(fitness)))
+        history["worst"].append(float(np.min(fitness)))
+
+        best_idx = int(np.argmax(fitness))
+        return {
+            "history": history,
+            "best_agent": population[best_idx],
+            "population": population,
+            "final_fitness": fitness,
+        }

--- a/sushigo/game.py
+++ b/sushigo/game.py
@@ -1,0 +1,221 @@
+"""Sushi Go game engine for 2 players, 3 rounds. No chopsticks."""
+
+from dataclasses import dataclass, field
+import numpy as np
+
+# Card type indices
+EGG_NIGIRI = 0
+SALMON_NIGIRI = 1
+SQUID_NIGIRI = 2
+MAKI_1 = 3
+MAKI_2 = 4
+MAKI_3 = 5
+TEMPURA = 6
+SASHIMI = 7
+DUMPLING = 8
+WASABI = 9
+PUDDING = 10
+
+NUM_CARD_TYPES = 11
+
+CARD_NAMES = [
+    "Egg Nigiri", "Salmon Nigiri", "Squid Nigiri",
+    "Maki 1", "Maki 2", "Maki 3",
+    "Tempura", "Sashimi", "Dumpling",
+    "Wasabi", "Pudding",
+]
+
+# Standard deck composition (no chopsticks)
+DECK_COUNTS = np.array([5, 10, 5, 6, 12, 8, 14, 14, 14, 6, 10], dtype=np.int32)
+
+NIGIRI_TYPES = {EGG_NIGIRI, SALMON_NIGIRI, SQUID_NIGIRI}
+NIGIRI_POINTS = {EGG_NIGIRI: 1, SALMON_NIGIRI: 2, SQUID_NIGIRI: 3}
+MAKI_SYMBOLS = {MAKI_1: 1, MAKI_2: 2, MAKI_3: 3}
+DUMPLING_SCORES = [0, 1, 3, 6, 10, 15]
+
+CARDS_PER_HAND = 10
+NUM_ROUNDS = 3
+
+
+@dataclass
+class PlayerState:
+    collected: np.ndarray = field(default_factory=lambda: np.zeros(NUM_CARD_TYPES, dtype=np.int32))
+    pudding_total: int = 0
+    unused_wasabi: int = 0
+    round_score: int = 0
+
+    def reset_round(self):
+        """Keep pudding_total and round_score, clear the rest for a new round."""
+        self.pudding_total += int(self.collected[PUDDING])
+        self.collected = np.zeros(NUM_CARD_TYPES, dtype=np.int32)
+        self.unused_wasabi = 0
+
+
+def _build_deck() -> list[int]:
+    """Return a list of card type ints representing the full deck."""
+    deck = []
+    for card_type, count in enumerate(DECK_COUNTS):
+        deck.extend([card_type] * count)
+    return deck
+
+
+def _hand_to_counts(hand: list[int]) -> np.ndarray:
+    """Convert a list of card ints to a count array of shape (NUM_CARD_TYPES,)."""
+    counts = np.zeros(NUM_CARD_TYPES, dtype=np.int32)
+    for card in hand:
+        counts[card] += 1
+    return counts
+
+
+def score_round(p1: PlayerState, p2: PlayerState) -> tuple[int, int]:
+    """Score a single round for both players. Modifies round_score in place."""
+    s1, s2 = 0, 0
+
+    # --- Maki rolls ---
+    maki1 = sum(int(p1.collected[m]) * sym for m, sym in MAKI_SYMBOLS.items())
+    maki2 = sum(int(p2.collected[m]) * sym for m, sym in MAKI_SYMBOLS.items())
+    if maki1 > maki2:
+        s1 += 6
+        s2 += 3
+    elif maki2 > maki1:
+        s2 += 6
+        s1 += 3
+    elif maki1 > 0:  # tied and non-zero
+        s1 += 3
+        s2 += 3
+
+    # --- Tempura (5 per pair) ---
+    s1 += (int(p1.collected[TEMPURA]) // 2) * 5
+    s2 += (int(p2.collected[TEMPURA]) // 2) * 5
+
+    # --- Sashimi (10 per set of 3) ---
+    s1 += (int(p1.collected[SASHIMI]) // 3) * 10
+    s2 += (int(p2.collected[SASHIMI]) // 3) * 10
+
+    # --- Dumplings ---
+    for p, acc in [(p1, lambda v: v), (p2, lambda v: v)]:
+        n = min(int(p.collected[DUMPLING]), 5)
+        if p is p1:
+            s1 += DUMPLING_SCORES[n]
+        else:
+            s2 += DUMPLING_SCORES[n]
+
+    # --- Nigiri (with wasabi already accounted during card placement) ---
+    # Nigiri points are scored during play via _place_card, stored in a running tally.
+    # But we count them here from collected cards. The wasabi-boosted nigiri were
+    # already handled: unused_wasabi tracks wasabi NOT yet paired.
+    # We need a different approach: track nigiri_points accumulated during play.
+    # Actually, let's just score nigiri simply here and handle wasabi during placement.
+    # During placement, when a nigiri is placed on wasabi, we add bonus points.
+    # Here we just score base nigiri points.
+    for nigiri, pts in NIGIRI_POINTS.items():
+        s1 += int(p1.collected[nigiri]) * pts
+        s2 += int(p2.collected[nigiri]) * pts
+
+    p1.round_score += s1
+    p2.round_score += s2
+    return s1, s2
+
+
+def score_pudding(p1: PlayerState, p2: PlayerState) -> tuple[int, int]:
+    """End-of-game pudding scoring."""
+    s1, s2 = 0, 0
+    pud1, pud2 = p1.pudding_total, p2.pudding_total
+    if pud1 > pud2:
+        s1 += 6
+        s2 -= 6
+    elif pud2 > pud1:
+        s2 += 6
+        s1 -= 6
+    # tie: no change
+    p1.round_score += s1
+    p2.round_score += s2
+    return s1, s2
+
+
+class SushiGoGame:
+    def __init__(self, rng: np.random.Generator | None = None):
+        self.rng = rng or np.random.default_rng()
+
+    def play(self, agent1, agent2) -> tuple[int, int]:
+        """Play a full 3-round game. Returns (score1, score2)."""
+        deck = _build_deck()
+        self.rng.shuffle(deck)
+        deck_idx = 0
+
+        p1 = PlayerState()
+        p2 = PlayerState()
+        # Track wasabi bonus points separately
+        wasabi_bonus = [0, 0]
+
+        for round_num in range(NUM_ROUNDS):
+            # Deal hands
+            hand1 = list(deck[deck_idx:deck_idx + CARDS_PER_HAND])
+            deck_idx += CARDS_PER_HAND
+            hand2 = list(deck[deck_idx:deck_idx + CARDS_PER_HAND])
+            deck_idx += CARDS_PER_HAND
+
+            for turn in range(CARDS_PER_HAND):
+                # Build state for each agent
+                hand1_counts = _hand_to_counts(hand1)
+                hand2_counts = _hand_to_counts(hand2)
+
+                state1 = {
+                    "my_collected": p1.collected.copy(),
+                    "my_unused_wasabi": p1.unused_wasabi,
+                    "hand": hand1_counts,
+                    "opp_collected": p2.collected.copy(),
+                    "opp_unused_wasabi": p2.unused_wasabi,
+                    "round": round_num,
+                    "cards_remaining": len(hand1),
+                }
+                state2 = {
+                    "my_collected": p2.collected.copy(),
+                    "my_unused_wasabi": p2.unused_wasabi,
+                    "hand": hand2_counts,
+                    "opp_collected": p1.collected.copy(),
+                    "opp_unused_wasabi": p1.unused_wasabi,
+                    "round": round_num,
+                    "cards_remaining": len(hand2),
+                }
+
+                pick1 = agent1.pick_card(state1)
+                pick2 = agent2.pick_card(state2)
+
+                # Validate picks are in hand
+                if pick1 not in hand1:
+                    pick1 = hand1[0]
+                if pick2 not in hand2:
+                    pick2 = hand2[0]
+
+                # Remove picked cards from hands
+                hand1.remove(pick1)
+                hand2.remove(pick2)
+
+                # Place cards
+                for pick, ps, bonus_idx in [(pick1, p1, 0), (pick2, p2, 1)]:
+                    ps.collected[pick] += 1
+                    if pick == WASABI:
+                        ps.unused_wasabi += 1
+                    elif pick in NIGIRI_TYPES and ps.unused_wasabi > 0:
+                        # Wasabi triples the nigiri: add 2x bonus (base counted in scoring)
+                        wasabi_bonus[bonus_idx] += NIGIRI_POINTS[pick] * 2
+                        ps.unused_wasabi -= 1
+
+                # Swap hands (pick-and-pass)
+                hand1, hand2 = hand2, hand1
+
+            # Score the round
+            score_round(p1, p2)
+            p1.round_score += wasabi_bonus[0]
+            p2.round_score += wasabi_bonus[1]
+            wasabi_bonus = [0, 0]
+
+            # Reset for next round (preserves pudding_total and round_score)
+            p1.reset_round()
+            p2.reset_round()
+
+        # Score pudding
+        score_pudding(p1, p2)
+
+        return p1.round_score, p2.round_score


### PR DESCRIPTION
Implement a complete Sushi Go card game simulator with two-player support, featuring neural network-based agents evolved via genetic algorithm. 

The game engine handles all card types (except chopsticks), pick-and-pass mechanics, and correct scoring including wasabi bonuses. Agents are controlled by small feedforward networks (37→16→11, 795 weights) whose weights form the GA chromosome. Evolution optimizes win rate against random play through tournament selection, crossover, and mutation.

Includes an interactive marimo notebook with hyperparameter controls (population size, generations, mutation rate), fitness-over-generations visualization showing win rate vs random agent, and agent preference analysis for different board states.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>