### PR TITLE
Fashion MNIST parallel coordinates explorer

### DIFF
--- a/13-params/README.md
+++ b/13-params/README.md
@@ -1,3 +1,8 @@
+---
+title: Readme
+marimo-version: 0.20.2
+---
+
 # 13 Parameters Is All You Need
 
 TinyLoRA training with GRPO on GSM8K math reasoning. Tracks experiments with WANDB.

--- a/barista-bench/menu.md
+++ b/barista-bench/menu.md
@@ -1,3 +1,8 @@
+---
+title: Menu
+marimo-version: 0.20.2
+---
+
 # BARISTA BENCH: OFFICIAL MENU & RULES (V2)
 
 ## 1. HOT COFFEES

--- a/btree_widget/btree_widget.py
+++ b/btree_widget/btree_widget.py
@@ -5,7 +5,7 @@
 
 import marimo
 
-__generated_with = "0.18.4"
+__generated_with = "0.20.2"
 app = marimo.App(width="full")
 
 
@@ -18,6 +18,7 @@ def _():
     import anywidget
     import traitlets
     import marimo as mo
+
     return Path, anywidget, bisect, copy, mo, traitlets
 
 
@@ -128,6 +129,7 @@ def _(bisect, copy):
         if tree is None:
             return make_node([], [])
         return copy.deepcopy(tree)
+
     return (
         build_btree,
         insert_key_with_steps,
@@ -243,6 +245,7 @@ def _(
             for value in remaining:
                 root = insert_key_with_steps(root, value, max_keys, steps)
             return self._build_steps_view(steps, f"Remove {key}")
+
     return (BTreeWidget,)
 
 

--- a/fashion-mnist-parallel.py
+++ b/fashion-mnist-parallel.py
@@ -1,0 +1,125 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "marimo",
+#     "polars",
+#     "numpy==2.4.2",
+#     "scikit-learn",
+#     "wigglystuff",
+#     "matplotlib==3.10.8",
+#     "pandas==3.0.1",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.20.2"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    import numpy as np
+    import polars as pl
+    from sklearn.datasets import fetch_openml
+    from sklearn.decomposition import PCA
+    from wigglystuff import ParallelCoordinates
+    import matplotlib.pyplot as plt
+
+    return PCA, ParallelCoordinates, fetch_openml, mo, np, pl, plt
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    # Fashion MNIST — Parallel Coordinates
+
+    This notebook loads the Fashion MNIST dataset, reduces the 784 pixel features
+    down to a handful of PCA components, and visualizes them with an interactive
+    parallel coordinates plot. Use the brushes on each axis to filter and explore
+    how different clothing categories separate in PCA space.
+    """)
+    return
+
+
+@app.cell
+def _(fetch_openml, np):
+    mnist = fetch_openml("Fashion-MNIST", version=1, as_frame=False, parser="auto")
+    images = mnist.data.astype(np.float32)
+    labels = mnist.target.astype(int)
+
+    label_names = {
+        0: "T-shirt/top",
+        1: "Trouser",
+        2: "Pullover",
+        3: "Dress",
+        4: "Coat",
+        5: "Sandal",
+        6: "Shirt",
+        7: "Sneaker",
+        8: "Bag",
+        9: "Ankle boot",
+    }
+    return images, label_names, labels
+
+
+@app.cell
+def _(mo):
+    n_samples_slider = mo.ui.slider(
+        start=500, stop=5000, step=500, value=2000, label="Number of samples"
+    )
+    n_components_slider = mo.ui.slider(start=3, stop=15, step=1, value=8, label="PCA components")
+    mo.hstack([n_samples_slider, n_components_slider])
+    return n_components_slider, n_samples_slider
+
+
+@app.cell
+def _(
+    PCA,
+    images,
+    label_names,
+    labels,
+    n_components_slider,
+    n_samples_slider,
+    np,
+    pl,
+):
+    rng = np.random.default_rng(42)
+    idx = rng.choice(len(images), size=n_samples_slider.value, replace=False)
+
+    pca = PCA(n_components=n_components_slider.value)
+    components = pca.fit_transform(images[idx])
+
+    df = pl.DataFrame(
+        {f"PC{i + 1}": components[:, i] for i in range(n_components_slider.value)}
+    ).with_columns(pl.Series("label", [label_names[labels[i]] for i in idx]))
+    return df, idx
+
+
+@app.cell
+def _(ParallelCoordinates, df, mo):
+    widget = mo.ui.anywidget(ParallelCoordinates(df, color_by="label"))
+    widget
+    return (widget,)
+
+
+@app.cell
+def _(idx, images, label_names, labels, np, plt, widget):
+    filtered = widget.widget.filtered_indices
+    sample_idx = np.array(filtered[:10]) if len(filtered) >= 10 else np.array(filtered)
+
+    fig, axes = plt.subplots(1, len(sample_idx), figsize=(2 * len(sample_idx), 2))
+    if len(sample_idx) == 1:
+        axes = [axes]
+    for _ax, _si in zip(axes, sample_idx):
+        _ax.imshow(images[idx[_si]].reshape(28, 28), cmap="gray")
+        _ax.set_title(label_names[labels[idx[_si]]], fontsize=9)
+        _ax.axis("off")
+    plt.tight_layout()
+    fig
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/fireworks_widget/fireworks_widget.py
+++ b/fireworks_widget/fireworks_widget.py
@@ -5,7 +5,7 @@
 
 import marimo
 
-__generated_with = "0.18.4"
+__generated_with = "0.20.2"
 app = marimo.App(width="full")
 
 
@@ -15,6 +15,7 @@ def _():
     import anywidget
     import traitlets
     import marimo as mo
+
     return Path, anywidget, mo, traitlets
 
 
@@ -33,6 +34,7 @@ def _(Path, anywidget, traitlets):
         def launch(self):
             """Trigger fireworks animation from Python"""
             self.trigger += 1
+
     return (FireworksWidget,)
 
 

--- a/grpo_gdpo_widget/grpo_gdpo_widget.py
+++ b/grpo_gdpo_widget/grpo_gdpo_widget.py
@@ -11,7 +11,7 @@
 
 import marimo
 
-__generated_with = "0.19.2"
+__generated_with = "0.20.2"
 app = marimo.App(width="medium")
 
 
@@ -54,6 +54,7 @@ def _(mo):
 def _():
     import marimo as mo
     from widget import GrpoGdpoWidget
+
     return GrpoGdpoWidget, mo
 
 
@@ -140,6 +141,7 @@ def _():
                 logits[i] += lr * grad
 
         return np.array(history)
+
     return (train_policy,)
 
 
@@ -160,6 +162,7 @@ def _():
             [r["correctness"], r["style"], r["conciseness"]]
             for r in rewards_list
         ], dtype=_np.float64)
+
     return (widget_rewards_to_array,)
 
 

--- a/max-rl/README.md
+++ b/max-rl/README.md
@@ -1,3 +1,8 @@
+---
+title: Readme
+marimo-version: 0.20.2
+---
+
 # MaxRL vs GRPO Benchmark
 
 Compares two advantage estimation methods (MaxRL and GRPO) on a Subset Sum task using Qwen models with LoRA fine-tuning. Based on the [Maximum Likelihood Reinforcement Learning](https://arxiv.org/abs/2602.02710) paper by Tajwar et al. (2026).

--- a/prisoners-benchmark/README.md
+++ b/prisoners-benchmark/README.md
@@ -1,3 +1,8 @@
+---
+title: Readme
+marimo-version: 0.20.2
+---
+
 # Prisoner Simulation Benchmarks
 
 Performance comparison of different implementations for the [100 prisoners problem](https://en.wikipedia.org/wiki/100_prisoners_problem) simulation.

--- a/prisoners-benchmark/run_benchmarks.py
+++ b/prisoners-benchmark/run_benchmarks.py
@@ -10,7 +10,7 @@
 
 import marimo
 
-__generated_with = "0.18.4"
+__generated_with = "0.20.2"
 app = marimo.App(width="medium")
 
 
@@ -23,6 +23,7 @@ def _():
     import shutil
     import os
     import numpy as np
+
     return mo, np, os, sys, time
 
 
@@ -45,6 +46,7 @@ def _(mo):
 def _():
     from bench_python import simulate_python, simulate_numpy
     from bench_numba import simulate_numba, warmup as warmup_numba
+
     return simulate_numba, simulate_numpy, simulate_python, warmup_numba
 
 
@@ -78,6 +80,7 @@ def _(os, sys, time):
         results = simulate_mojo_direct(n_prisoners, n_sims)
         elapsed = time.perf_counter() - start
         return elapsed, list(results)
+
     return (simulate_mojo_wrapper,)
 
 
@@ -107,6 +110,7 @@ def _(np, time):
         print(mean1, mean2)
         relative_diff = abs(mean1 - mean2) / max(mean1, mean2)
         return relative_diff < tolerance
+
     return benchmark, verify_distribution
 
 

--- a/zstd-bench/README.md
+++ b/zstd-bench/README.md
@@ -1,3 +1,8 @@
+---
+title: Readme
+marimo-version: 0.20.2
+---
+
 # Zstd Compression Classifiers
 
 Benchmarking classification via zstd compression dictionaries across text and image domains. Based on [Max Halford's blog post](https://maxhalford.github.io/blog/text-classification-zstd/).


### PR DESCRIPTION
## Summary
- Adds an interactive marimo notebook that loads Fashion MNIST, reduces 784 pixel features to PCA components, and visualizes them with `wigglystuff.ParallelCoordinates` colored by clothing category
- Includes sliders for sample count and number of PCA components
- Shows a grid of 10 sample images from the current filtered selection
- Fixes `marimo check` warnings across existing notebooks

## Test plan
- [ ] `uvx marimo check fashion-mnist-parallel.py` passes
- [ ] `uv run marimo edit fashion-mnist-parallel.py` — widget renders with colored lines, brushing filters update the image grid below

🤖 Generated with [Claude Code](https://claude.com/claude-code)