### PR TITLE
Add implement-paper skill and expand marimo-notebook references

### DIFF
--- a/.agents/skills/implement-paper/SKILL.md
+++ b/.agents/skills/implement-paper/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: implement-paper
+description: Implement a research paper as an interactive marimo notebook. Starts by understanding what the user wants to explore, fetches the paper via alphaxiv, then builds a focused notebook.
+---
+
+# Implement Paper
+
+Turn a research paper into an interactive marimo notebook. For general marimo notebook conventions (cell structure, PEP 723 metadata, output rendering, `marimo check`, variable naming, etc.), refer to the `marimo-notebook` skill.
+
+## Step 1: Understand what the user wants
+
+Before fetching or reading anything, have a short conversation to scope the work. Ask the user:
+
+- **Which part of the paper interests you most?** A paper may have multiple contributions — the user likely cares about one or two. Don't implement the whole thing.
+- **What's the goal?** Are they trying to understand the method, reproduce a result, adapt it to their own data, or teach it to someone else? This changes the notebook's tone and depth.
+- **Do they want to use a specific dataset?** If it's relevant, ask. Otherwise, suggest simulating data.
+- **Does this require PyTorch?** Some papers need it, many don't. Ask if unclear — it's a heavy dependency.
+- **What's their background?** The paper aims to fill a knowledge gap — gauge what the user already knows so the notebook can meet them where they are. Skip basics they're familiar with, explain prerequisites they're not.
+
+Only move on once you have a clear picture of what to build.
+
+## Step 2: Fetch the paper
+
+See [references/fetching-papers.md](references/fetching-papers.md) for how to retrieve paper content via alphaxiv.org. This avoids reading raw PDFs and gives you structured markdown.
+
+## Step 3: Plan the notebook
+
+After reading the paper, outline the notebook structure for the user before writing code.
+
+**Keep the notebook as small as possible.** Sometimes the idea is best conveyed with just a single interactive widget — if you need a custom one, consider the `anywidget` skill. Other times you need a full training loop — if so, consider using the `marimo-batch` skill for heavy computation. The goal is the minimum amount of code needed to get the idea across.
+
+A typical arc:
+
+| Section | Purpose | Typical elements |
+|---------|---------|------------------|
+| Title & context | Orient the reader | `mo.md()` with paper title, authors, link |
+| Background | Set up prerequisites | Markdown + equations |
+| Method | Core algorithm step-by-step | Code + markdown interleaved |
+| Experiments | Reproduce key results | Interactive widgets + plots |
+| Conclusion | Summarize takeaways | `mo.md()` |
+
+Not every notebook needs all sections. Share the outline with the user and adjust before writing code.
+
+## Step 4: Build the notebook
+
+Create the marimo notebook following the `marimo-notebook` skill conventions.
+
+Key guidelines:
+
+- **Never assume the dataset.** Use whatever the user specified in Step 1. If they didn't specify one, simulate data.
+- **Make it self-contained.** A reader should understand the notebook without reading the full paper.
+- **Use KaTeX for equations.** Render key equations with `mo.md(r"""$...$""")` so the notebook mirrors the paper's notation. Keep notation consistent with the paper.
+- **Add interactivity where it aids understanding.** Sliders for hyperparameters, dropdowns for dataset variants, or toggles for ablations help readers build intuition.
+- **Show, don't just tell.** Prefer a plot or table over a paragraph of explanation.
+- **Name variables to match the paper's notation** where practical (e.g., `alpha`, `X`, `W`), and add comments mapping them to equation numbers.
+
+## Tips
+
+- **Don't reproduce the entire paper.** Focus on what the user asked about in Step 1.
+- **Iterate visually.** Build up figures incrementally (e.g., show data → show model fit → show residuals) rather than dumping everything into one plot.
+- **If the paper uses heavy notation**, include a small "notation reference" cell with a markdown table mapping symbols to descriptions.

--- a/.agents/skills/implement-paper/references/anywidget.md
+++ b/.agents/skills/implement-paper/references/anywidget.md
@@ -1,0 +1,79 @@
+---
+name: anywidget-generator
+description: Generate anywidget components for marimo notebooks.
+---
+
+When writing an anywidget use vanilla javascript in `_esm` and do not forget about `_css`. The css should look bespoke in light mode and dark mode. Keep the css small unless explicitly asked to go the extra mile. When you display the widget it must be wrapped via `widget = mo.ui.anywidget(OriginalAnywidget())`. You can also point `_esm` and `_css` to external files if needed using pathlib. This makes sense if the widget does a lot of elaborate JavaScript or CSS.
+
+<example title="Example of simple anywidget implementation">
+import anywidget
+import traitlets
+
+
+class CounterWidget(anywidget.AnyWidget):
+    _esm = """
+    // Define the main render function
+    function render({ model, el }) {
+      let count = () => model.get("number");
+      let btn = document.createElement("b8utton");
+      btn.innerHTML = `count is ${count()}`;
+      btn.addEventListener("click", () => {
+        model.set("number", count() + 1);
+        model.save_changes();
+      });
+      model.on("change:number", () => {
+        btn.innerHTML = `count is ${count()}`;
+      });
+      el.appendChild(btn);
+    }
+    // Important! We must export at the bottom here!
+    export default { render };
+    """
+    _css = """button{
+      font-size: 14px;
+    }"""
+    number = traitlets.Int(0).tag(sync=True)
+
+widget = mo.ui.anywidget(CounterWidget())
+widget
+
+# Grabbing the widget from another cell, `.value` is a dictionary.
+print(widget.value["number"])
+</example>
+
+The above is a minimal example that could work for a simple counter widget. In general the widget can become much larger because of all the JavaScript and CSS required. Unless the widget is dead simple, you should consider using external files for `_esm` and `_css` using pathlib. 
+
+When sharing the anywidget, keep the example minimal. No need to combine it with marimo ui elements unless explicitly stated to do so.
+
+## Best Practices
+
+Unless specifically told otherwise, assume the following:
+
+1. **Use vanilla JavaScript in `_esm`**:
+   - Define a `render` function that takes `{ model, el }` as parameters
+   - Use `model.get()` to read trait values
+   - Use `model.set()` and `model.save_changes()` to update traits
+   - Listen to changes with `model.on("change:traitname", callback)`
+   - Export default with `export default { render };` at the bottom
+   - All widgets inherit from `anywidget.AnyWidget`, so `widget.observe(handler)`
+     remains the standard way to react to state changes.
+   - Python constructors tend to validate bounds, lengths, or choice counts; let the
+     raised `ValueError/TraitError` guide you instead of duplicating the logic.
+
+2. **Include `_css` styling**:
+   - Keep CSS minimal unless explicitly asked for more
+   - Make it look bespoke in both light and dark mode
+   - Use CSS media query for dark mode: `@media (prefers-color-scheme: dark) { ... }`
+
+3. **Wrap the widget for display**:
+   - Always wrap with marimo: `widget = mo.ui.anywidget(OriginalAnywidget())`
+   - Access values via `widget.value` which returns a dictionary
+
+4. **Keep examples minimal**:
+   - Add a marimo notebook that highlights the core utility
+   - Show basic usage only
+   - Don't combine with other marimo UI elements unless explicitly requested
+
+Dumber is better. Prefer obvious, direct code over clever abstractions—someone
+new to the project should be able to read the code top-to-bottom and grok it
+without needing to look up framework magic or trace through indirection.

--- a/.agents/skills/implement-paper/references/fetching-papers.md
+++ b/.agents/skills/implement-paper/references/fetching-papers.md
@@ -1,0 +1,39 @@
+# Fetching Papers via AlphaXiv
+
+Use alphaxiv.org to get structured, LLM-friendly paper content. This is faster and more reliable than trying to read a raw PDF.
+
+## Extract the paper ID
+
+Parse the paper ID from whatever the user provides:
+
+| Input | Paper ID |
+|-------|----------|
+| `https://arxiv.org/abs/2401.12345` | `2401.12345` |
+| `https://arxiv.org/pdf/2401.12345` | `2401.12345` |
+| `https://alphaxiv.org/overview/2401.12345` | `2401.12345` |
+| `2401.12345v2` | `2401.12345v2` |
+| `2401.12345` | `2401.12345` |
+
+## Fetch the AI-generated overview (try this first)
+
+```bash
+curl -s "https://alphaxiv.org/overview/{PAPER_ID}.md"
+```
+
+Returns a structured, detailed analysis of the paper as plain markdown. One call, no JSON parsing.
+
+## Fetch the full paper text (fallback)
+
+If the overview doesn't contain the specific detail you need (e.g., a particular equation, table, or proof):
+
+```bash
+curl -s "https://alphaxiv.org/abs/{PAPER_ID}.md"
+```
+
+Returns the full extracted text of the paper as markdown.
+
+## Error handling
+
+- **404 on the overview**: Report hasn't been generated for this paper yet. Try the full text instead.
+- **404 on the full text**: Text hasn't been processed yet. As a last resort, direct the user to the PDF at `https://arxiv.org/pdf/{PAPER_ID}`.
+- No authentication is required — these are public endpoints.

--- a/.agents/skills/marimo-batch/SKILL.md
+++ b/.agents/skills/marimo-batch/SKILL.md
@@ -32,6 +32,13 @@ But you can also use the CLI from marimo.
 
 ```python
 if mo.app_meta().mode == "script":
+    if "help" in mo.cli_args() or len(cli_args) == 0:
+        print("Usage: uv run git_archaeology.py --repo <url> [--samples <n>]")
+        print()
+        for name, field in ModelParams.model_fields.items():
+            default = f" (default: {field.default})" if field.default is not None else " (required)"
+            print(f"  --{name:12s} {field.description}{default}")
+        exit()
     model_params = ModelParams(
         **{k.replace("-", "_"): v for k, v in mo.cli_args().items()
     })

--- a/.agents/skills/marimo-notebook/SKILL.md
+++ b/.agents/skills/marimo-notebook/SKILL.md
@@ -5,6 +5,62 @@ description: Write a marimo notebook in a Python file in the right format.
 
 # Notes for marimo Notebooks
 
+marimo uses Python to create notebooks, unlike Jupyter which uses JSON. Here's an example notebook: 
+
+```python
+# /// script
+# dependencies = [
+#     "marimo",
+#     "numpy==2.4.3",
+# ]
+# requires-python = ">=3.14"
+# ///
+
+import marimo
+
+__generated_with = "0.20.4"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    import numpy as np
+
+    return mo, np
+
+
+@app.cell
+def _():
+    print("hello world")
+    return
+
+
+@app.cell
+def _(np, slider):
+    np.array([1,2,3]) + slider.value
+    return
+
+
+@app.cell
+def _(mo):
+    slider = mo.ui.slider(1, 10, 1, label="number to add")
+    slider
+    return (slider,)
+
+
+@app.cell
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()
+
+```
+
+Notice how the notebook is structured with functions can represent cell contents. Each cell is defined with the `@app.cell` decorator and the inputs/outputs of the function are the inputs/outputs of the cell. marimo usually takes care of the dependencies between cells automatically. 
+
 ## Running Marimo Notebooks
 
 ```bash
@@ -82,6 +138,10 @@ def _(is_script_mode, train_button, lr_slider, run_training, X_data, y_data):
             results = run_training(X_data, y_data, lr=lr_slider.value)
     return (results,)
 ```
+
+## State and Reactivity
+
+Variables between cells define the reactivity of the notebook for 99% of the use-cases out there. No special state management needed. Don't mutate objects across cells (e.g., `my_list.append()`); create new objects instead. Avoid `mo.state()` unless you need bidirectional UI sync or accumulated callback state. See [STATE.md](references/STATE.md) for details.
 
 ## Don't Guard Cells with `if` Statements
 
@@ -168,6 +228,8 @@ for _name, _model in items:
 
 ## PEP 723 Dependencies
 
+Notebooks created via `marimo edit --sandbox` have these dependencies added to the top of the file automatically but it is a good practice to make sure these exist when creating a notebook too: 
+
 ```python
 # /// script
 # requires-python = ">=3.12"
@@ -177,22 +239,6 @@ for _name, _model in items:
 # ]
 # ///
 ```
-
-## Prefer pathlib over os.path
-
-Use `pathlib.Path` for file path operations instead of `os.path`:
-
-```python
-# GOOD - use pathlib
-from pathlib import Path
-data_dir = Path(tempfile.mkdtemp())
-parquet_file = data_dir / "data.parquet"
-
-# BAD - avoid os.path
-import os
-parquet_file = os.path.join(temp_dir, "data.parquet")
-```
-
 
 ## marimo check 
 
@@ -212,8 +258,28 @@ If the user specifically wants you to use a marimo function, you can locally che
 uv --with marimo run python -c "import marimo as mo; help(mo.ui.form)"
 ```
 
+## tests 
+
+By default, marimo discovers and executes tests inside your notebook.
+When the optional `pytest` dependency is present, marimo runs `pytest` on cells that
+consist exclusively of test code - i.e. functions whose names start with `test_`. 
+If the user asks you to add tests, make sure to add the `pytest` dependency is added and that
+there is a cell that contains only test code.
+
+For more information on testing with pytest see [PYTEST.md](references/PYTEST.md)
+
+Once tests are added, you can run pytest from the commandline on the notebook to run pytest. 
+
+```
+pytest <notebook.py>
+```
+
 ## Additional resources
 
 - For SQL use in marimo see [SQL.md](references/SQL.md)
 - For UI elements in marimo [UI.md](references/UI.md)
 - For exposing functions/classes as top level imports [TOP-LEVEL-IMPORTS.md](references/TOP-LEVEL-IMPORTS.md)
+- For exporting notebooks (PDF, HTML, markdown, etc.) [EXPORTS.md](references/EXPORTS.md)
+- For state management and reactivity [STATE.md](references/STATE.md)
+- For deployment of marimo notebooks [DEPLOYMENT.md](references/DEPLOYMENT.md)
+- For custom interactive widgets with anywidget [ANYWIDGET.md](references/ANYWIDGET.md)

--- a/.agents/skills/marimo-notebook/references/ANYWIDGET.md
+++ b/.agents/skills/marimo-notebook/references/ANYWIDGET.md
@@ -1,0 +1,79 @@
+---
+name: anywidget-generator
+description: Generate anywidget components for marimo notebooks.
+---
+
+When writing an anywidget use vanilla javascript in `_esm` and do not forget about `_css`. The css should look bespoke in light mode and dark mode. Keep the css small unless explicitly asked to go the extra mile. When you display the widget it must be wrapped via `widget = mo.ui.anywidget(OriginalAnywidget())`. You can also point `_esm` and `_css` to external files if needed using pathlib. This makes sense if the widget does a lot of elaborate JavaScript or CSS.
+
+<example title="Example of simple anywidget implementation">
+import anywidget
+import traitlets
+
+
+class CounterWidget(anywidget.AnyWidget):
+    _esm = """
+    // Define the main render function
+    function render({ model, el }) {
+      let count = () => model.get("number");
+      let btn = document.createElement("b8utton");
+      btn.innerHTML = `count is ${count()}`;
+      btn.addEventListener("click", () => {
+        model.set("number", count() + 1);
+        model.save_changes();
+      });
+      model.on("change:number", () => {
+        btn.innerHTML = `count is ${count()}`;
+      });
+      el.appendChild(btn);
+    }
+    // Important! We must export at the bottom here!
+    export default { render };
+    """
+    _css = """button{
+      font-size: 14px;
+    }"""
+    number = traitlets.Int(0).tag(sync=True)
+
+widget = mo.ui.anywidget(CounterWidget())
+widget
+
+# Grabbing the widget from another cell, `.value` is a dictionary.
+print(widget.value["number"])
+</example>
+
+The above is a minimal example that could work for a simple counter widget. In general the widget can become much larger because of all the JavaScript and CSS required. Unless the widget is dead simple, you should consider using external files for `_esm` and `_css` using pathlib. 
+
+When sharing the anywidget, keep the example minimal. No need to combine it with marimo ui elements unless explicitly stated to do so.
+
+## Best Practices
+
+Unless specifically told otherwise, assume the following:
+
+1. **Use vanilla JavaScript in `_esm`**:
+   - Define a `render` function that takes `{ model, el }` as parameters
+   - Use `model.get()` to read trait values
+   - Use `model.set()` and `model.save_changes()` to update traits
+   - Listen to changes with `model.on("change:traitname", callback)`
+   - Export default with `export default { render };` at the bottom
+   - All widgets inherit from `anywidget.AnyWidget`, so `widget.observe(handler)`
+     remains the standard way to react to state changes.
+   - Python constructors tend to validate bounds, lengths, or choice counts; let the
+     raised `ValueError/TraitError` guide you instead of duplicating the logic.
+
+2. **Include `_css` styling**:
+   - Keep CSS minimal unless explicitly asked for more
+   - Make it look bespoke in both light and dark mode
+   - Use CSS media query for dark mode: `@media (prefers-color-scheme: dark) { ... }`
+
+3. **Wrap the widget for display**:
+   - Always wrap with marimo: `widget = mo.ui.anywidget(OriginalAnywidget())`
+   - Access values via `widget.value` which returns a dictionary
+
+4. **Keep examples minimal**:
+   - Add a marimo notebook that highlights the core utility
+   - Show basic usage only
+   - Don't combine with other marimo UI elements unless explicitly requested
+
+Dumber is better. Prefer obvious, direct code over clever abstractions—someone
+new to the project should be able to read the code top-to-bottom and grok it
+without needing to look up framework magic or trace through indirection.

--- a/.agents/skills/marimo-notebook/references/DEPLOYMENT.md
+++ b/.agents/skills/marimo-notebook/references/DEPLOYMENT.md
@@ -1,0 +1,41 @@
+## Running notebooks
+
+You can deploy a single marimo notebook as a web app:
+
+```bash
+uvx marimo run --sandbox notebook.py
+```
+
+The `--sandbox` flag makes sure the notebook runs in an isolated UV environment.
+
+Or deploy a folder of notebooks as a web app with multiple notebooks. Also here, you can use the `--sandbox` flag to run each notebook in its own isolated environment, using the PEP 723 dependencies declared in each notebook:
+
+```bash
+uvx marimo run --sandbox <folder>
+```
+
+### Thumbnails
+
+When you host multiple notebooks you may want to generate thumbnails. You can generate OpenGraph thumbnails for notebooks using:
+
+```bash
+uvx marimo export thumbnail notebook.py
+uvx marimo export thumbnail folder/
+```
+
+Thumbnails are stored at `__marimo__/assets/<notebook_stem>/opengraph.png`. The user may also put screenshots there manually. 
+
+Besides images, you can also add metadata to the notebooks by adding to the PEP 723 Dependencies on top of the file. These will appear in an overview if the user deploys a folder of notebooks. 
+
+```
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "marimo",
+#     "polars==1.37.1",
+# ]
+# [tool.marimo.opengraph]
+# title = "My dashboard"
+# description = "Tracking my portfolio over time"
+# ///
+```

--- a/.agents/skills/marimo-notebook/references/EXPORTS.md
+++ b/.agents/skills/marimo-notebook/references/EXPORTS.md
@@ -1,0 +1,66 @@
+marimo can export notebooks to several formats via the CLI.
+
+```
+> uvx marimo export --help
+Usage: marimo export [OPTIONS]
+                     COMMAND [ARGS]...
+
+  Export a notebook to various formats.
+
+Options:
+  -h, --help  Show this message and exit.
+
+Commands:
+  html       Run a notebook and export it as an HTML file.
+  html-wasm  Export a notebook as a WASM- powered marimo notebook. 
+  ipynb      Export a marimo notebook as a Jupyter notebook
+  md         Export a marimo notebook as a code fenced markdown file
+  pdf        Export a marimo notebook as a PDF file.
+  script     Export a marimo notebook as a flat script
+  session    Execute a notebook or directory of notebooks and export session snapshots.
+  thumbnail  Generate OpenGraph thumbnails for notebooks.
+```
+
+You can learn more about each option by calling the command with the `--help` flag. 
+
+## PDF Export
+
+Many people may be interested in exporting to a PDF. 
+
+```bash
+uvx marimo export pdf notebook.py -o notebook.pdf
+```
+
+PDF export uses `nbformat` and `nbconvert` under the hood. By default it uses the WebPDF exporter which requires Chromium. Install the dependencies:
+
+```bash
+uv pip install nbformat nbconvert
+playwright install chromium
+```
+
+Useful flags:
+
+- `--no-include-inputs` — hide code cells, show only outputs
+- `--no-include-outputs` — include only code, skip outputs
+- `--as=slides` — export as a slide deck PDF (uses reveal.js slide boundaries)
+- `--raster-scale 4.0` — controls output sharpness (1.0–4.0, default 4.0)
+- `--raster-server=live` — use when a widget needs a running Python kernel to render (recommended for slides)
+
+## Script Export
+
+```bash
+uvx marimo export script notebook.py -o notebook.script.py
+```
+
+Flattens the notebook into a plain Python script in topological order.
+
+## Common Flags
+
+These flags work across most export subcommands:
+
+- `-o`, `--output` — output file path
+- `--watch` — re-export automatically when the notebook file changes
+- `--sandbox` — run in an isolated `uv` environment
+- `-f`, `--force` — overwrite if output file already exists
+- `--` — pass CLI arguments to the notebook, e.g. `uvx marimo export html notebook.py -o out.html -- --arg value`
+- `-y` automatic yes to prompts on the terminal `uvx marimo -y CMD ...` 

--- a/.agents/skills/marimo-notebook/references/PYTEST.md
+++ b/.agents/skills/marimo-notebook/references/PYTEST.md
@@ -1,0 +1,212 @@
+# Testing with pytest
+
+## Testing in notebook
+
+When `pytest` is present, marimo runs `pytest` on cells that
+consist exclusively of test code - i.e. functions whose names start with `test_`,
+classes whose names start with `Test`, or functions decorated with `@pytest.fixture`.
+If a cell mixes in anything else (helper functions, constants, variables, imports, etc.),
+that cell is skipped by the test runner (we recommend you move helpers to another cell).
+
+For example:
+
+```python
+@app.cell
+def __():
+    import pytest
+    def inc(x):
+        return x + 1
+    return inc, pytest
+
+@app.cell
+def __(inc, pytest):
+    class TestBlock:
+        @staticmethod
+        def test_fails():
+            assert inc(3) == 5, "This test fails"
+
+        @staticmethod
+        def test_sanity():
+            assert inc(3) == 4, "This test passes"
+
+    @pytest.mark.parametrize(("x", "y"), [(3, 4), (4, 5)])
+    def test_parameterized(x, y):
+        assert inc(x) == y
+    return
+```
+
+Reactive tests can be disabled. You can disable this behavior with the `runtime.reactive_test` option in the
+configuration file.
+
+## Testing at the command-line
+
+```bash
+pytest <notebook.py>
+```
+
+runs and tests all notebook cells whose names start with `test_`, or cells that
+contain only `test_` functions and `Test` classes (just like in notebook tests).
+
+## Example
+
+Running `pytest` on
+
+```python
+# content of test_notebook.py
+import marimo
+
+__generated_with = "0.10.6"
+app = marimo.App()
+
+
+@app.cell
+def _():
+    def inc(x):
+        return x + 1
+    return (inc,)
+
+
+@app.cell
+def test_fails(inc):
+    assert inc(3) == 5, "This test fails"
+
+
+@app.cell
+def test_sanity(inc):
+    assert inc(3) == 4, "This test passes"
+
+@app.cell
+def collection_of_tests(inc, pytest):
+    @pytest.mark.parametrize(("x", "y"), [(3, 4), (4, 5)])
+    def test_answer(x, y):
+        assert inc(x) == y, "These tests should pass."
+
+@app.cell
+def imports():
+    import pytest
+    return pytest
+```
+
+prints
+
+```pytest
+============================= test session starts ==============================
+platform linux -- Python 3.12.9, pytest-8.3.5, pluggy-1.5.0
+rootdir: /notebooks
+configfile: pyproject.toml
+collected 4 items
+
+test_notebook.py::test_fails FAILED                                       [ 25%]
+test_notebook.py::test_sanity PASSED                                      [ 50%]
+test_notebook.py::MarimoTestBlock_0::test_parameterized[3-4] PASSED       [ 75%]
+test_notebook.py::MarimoTestBlock_0::test_parameterized[4-5] PASSED       [100%]
+
+=================================== FAILURES ===================================
+__________________________________ test_fails __________________________________
+
+    # content of test_notebook.py
+    import marimo
+
+    __generated_with = "0.10.6"
+    app = marimo.App()
+
+
+    @app.cell
+    def _():
+        def inc(x):
+            return x + 1
+        return (inc,)
+
+
+    @app.cell
+    def test_fails(inc):
+>       assert inc(3) == 5, "This test fails"
+E       AssertionError: This test fails
+E       assert 4 == 5
+E        +  where 4 = <function inc>(3)
+
+test_notebook.py:17: AssertionError
+=========================== short test summary info ============================
+FAILED test_notebook.py::test_fails - AssertionError: This test fails
+========================= 1 failed, 3 passed in 0.82s ==========================
+```
+
+## Using Pytest Fixtures
+
+
+marimo supports pytest fixtures, with one limitation: fixtures defined in one cell cannot be used in another cell, unless the fixtures were defined in the setup cell.
+
+**Fixtures defined in the setup cell**:
+
+```python
+# test_notebook.py
+import marimo
+app = marimo.App()
+
+with app.setup:
+    from fixtures import db_connection, sample_data
+
+@app.cell
+def _(sample_data):
+    def test_data_loaded(sample_data):
+        assert len(sample_data) > 0
+```
+
+**Fixtures in the same cell as tests**:
+
+```python
+@app.cell
+def _():
+    import pytest
+    return pytest
+
+
+@app.cell
+def _(pytest):
+    @pytest.fixture
+    def temp_file():
+        import tempfile
+        with tempfile.NamedTemporaryFile() as f:
+            yield f
+
+    def test_writes_to_file(temp_file):
+        temp_file.write(b"hello")
+        temp_file.seek(0)
+        assert temp_file.read() == b"hello"
+```
+
+**Class fixtures**:
+
+```python
+@app.cell
+def _():
+    import pytest
+    return pytest
+
+
+@app.cell
+def _(pytest):
+    class TestDatabase:
+        @pytest.fixture(scope="class")
+        def connection(self):
+            return create_connection()
+
+        def test_query(self, connection):
+            result = connection.query("SELECT 1")
+            assert result == 1
+```
+
+**`conftest.py` fixtures** work as expected - pytest discovers them automatically.
+
+### Fixture Limitations
+
+Fixtures defined in one cell **cannot** be used by tests in a different cell.
+This is because pytest collects tests **statically** by parsing the notebook
+file without executing it. During collection, pytest can see module-level
+fixtures (from `conftest.py` or imported modules) and fixtures defined in the
+same scope as the test, but it cannot see fixtures defined in other cells.
+
+**Why?** Running the entire notebook just for fixture discovery would be
+expensive, and static analysis cannot determine which fixtures will be
+available after cell execution since cell order is determined at runtime by
+marimo's dependency graph.

--- a/.agents/skills/marimo-notebook/references/SQL.md
+++ b/.agents/skills/marimo-notebook/references/SQL.md
@@ -5,7 +5,7 @@ There are multiple ways to use SQL in marimo. Under the hood, a SQL cell is just
 def _(df, mo):
     grouped = mo.sql(
         f"""
-        SELECT category, MEAN(value) as mean FROM df GROUP BY category ORDER BY mean;
+        SELECT category, AVG(value) as mean FROM df GROUP BY category ORDER BY mean;
         """,
         output=False
     )
@@ -22,7 +22,7 @@ def sql(query: str, *, output: bool=True, engine: Optional[DBAPIConnection]=None
 
 Typically a `sql` call returns a polars dataframe, but the user can configure pandas as an alternative. 
 
-Notice how a query string goes in with SQL and how you can pass a specific database engine. 
+Notice how a query string goes in with SQL and how you can pass a specific database engine. Be aware that different SQL engines may have different SQL dialects. 
 
 ## SQLAlchemy
 
@@ -58,7 +58,7 @@ from pyiceberg.catalog.rest import RestCatalog
 catalog = RestCatalog(
     name="catalog",
     warehouse="1234567890",
-    uri="https://my-catalog.com",
+    uri="https://example.com",
     token="my-token",
 )
 ```

--- a/.agents/skills/marimo-notebook/references/STATE.md
+++ b/.agents/skills/marimo-notebook/references/STATE.md
@@ -1,0 +1,94 @@
+# State in marimo
+
+## Reactivity IS State Management
+
+In marimo, regular Python variables between cells are your state. When a cell assigns a variable, all cells that read it re-run automatically. Widget values (`widget.value`) work the same way — interact with a widget and dependent cells re-execute. No store, no session_state, no hooks needed.
+
+## Don't Mutate Objects Across Cells
+
+marimo does **not** track mutations like `my_list.append(42)` or `obj.value = 42`.
+
+```python
+# BAD - mutation in another cell won't trigger re-runs
+# Cell 1
+items = [1, 2, 3]
+
+# Cell 2
+items.append(4)  # marimo won't know this happened
+
+# GOOD - create new objects instead
+# Cell 1
+items = [1, 2, 3]
+
+# Cell 2
+extended_items = items + [4]
+```
+
+## You Probably Don't Need `mo.state()`
+
+In 99% of cases, built-in reactivity is enough:
+
+- **Reading widget values** — just use `widget.value` in another cell
+- **Combining multiple inputs** — use `.batch().form()`
+- **Conditional data** — use `if`/`else` in one cell
+
+## When You Do Need `mo.state()`
+
+Use it when you need **accumulated state from callbacks** or **bidirectional sync** between UI elements.
+
+```python
+get_val, set_val = mo.state(initial_value)
+```
+
+- Read: `get_val()`
+- Update: `set_val(new_value)` or `set_val(lambda d: d + [new_item])`
+- The cell calling the setter does NOT re-run (unless `allow_self_loops=True`)
+
+### Example: todo list with accumulated state
+
+```python
+# Cell 1 — declare state
+@app.cell
+def _(mo):
+    get_items, set_items = mo.state([])
+    return get_items, set_items
+
+# Cell 2 — input form
+@app.cell
+def _(mo, set_items):
+    task = mo.ui.text(label="New task")
+    add = mo.ui.button(
+        label="Add",
+        on_click=lambda _: set_items(lambda d: d + [task.value])
+    )
+    mo.hstack([task, add])
+    return
+
+# Cell 3 — display (re-runs when state changes)
+@app.cell
+def _(mo, get_items):
+    mo.md("\n".join(f"- {t}" for t in get_items()))
+    return
+```
+
+### Example: syncing two UI elements
+
+```python
+@app.cell
+def _(mo):
+    get_n, set_n = mo.state(50)
+    return get_n, set_n
+
+@app.cell
+def _(mo, get_n, set_n):
+    slider = mo.ui.slider(0, 100, value=get_n(), on_change=set_n)
+    number = mo.ui.number(0, 100, value=get_n(), on_change=set_n)
+    mo.hstack([slider, number])
+    return
+```
+
+## Warnings
+
+- Don't store `mo.ui` elements inside state — causes hard-to-diagnose bugs.
+- Don't use `on_change` when you can just read `.value` from another cell.
+- Write idempotent cells — same inputs should produce same outputs.

--- a/.agents/skills/marimo-notebook/references/TOP-LEVEL-IMPORTS.md
+++ b/.agents/skills/marimo-notebook/references/TOP-LEVEL-IMPORTS.md
@@ -19,10 +19,12 @@ import marimo
 __generated_with = "0.19.11"
 app = marimo.App(width="medium")
 
+# Define setup cell
 with app.setup:
     import numpy as np
 
 
+# Define function cell
 @app.function
 def calculate_statistics(data):
     """Calculate basic statistics for a dataset"""
@@ -43,7 +45,7 @@ if __name__ == "__main__":
     app.run()
 ```
 
-In this example, the setup cell is represented as a context manager `app.setup` and the cell that contains `calculate_statistics` is represented as a function decorator `@app.function`. You can now import `calculate_statistics` from other Python scripts or notebooks.
+In this example, the setup cell is represented as a context manager `app.setup` and the cell that contains `calculate_statistics` is represented as a function decorator `@app.function`. You can now import `calculate_statistics` from other Python scripts or notebooks. There can be no more than one setup cell per notebook.
 
 ```python
 # In another_script.py

--- a/.agents/skills/marimo-notebook/references/UI.md
+++ b/.agents/skills/marimo-notebook/references/UI.md
@@ -23,9 +23,63 @@ marimo has a rich set of UI components.
 * `mo.ui.array(elements: list[mo.ui.Element])` - create an array of UI elements
 * `mo.ui.form(element: mo.ui.Element, label='', bordered=True)` - wrap an element in a form
 
-However, the user may also want to use other components. Popular alternatives include the `ScatterWidget` from the `drawdata` library, `moutils`, and `wigglystuff`. 
+As always, you can learn more about the available inputs to all these components via `uv --with marimo run python -c "import marimo as mo; help(mo.ui.form)"` 
 
-The wigglystuff API can be explored [here](https://koaning.github.io/wigglystuff/llms.txt). 
+## Forms
+
+You can compose multiple UI elements into a single form using `.batch().form()`. The `.batch()` method binds named UI elements into a markdown template, and `.form()` adds a submit button so values are only sent on submit.
+
+```python
+form = (
+    mo.md(
+        """
+        **Choose an option**
+
+        {choice}
+
+        **Enter some text**
+
+        {text}
+
+        **Enable feature**
+
+        {flag}
+        """
+    )
+    .batch(
+        choice=mo.ui.dropdown(options=["A", "B", "C"]),
+        text=mo.ui.text(),
+        flag=mo.ui.checkbox(),
+    )
+    .form(
+        submit_button_label="Submit",
+        show_clear_button=True,   # optional
+        clear_on_submit=False,    # keep values after submit
+    )
+)
+
+form
+```
+
+You can also add validation to a form using the `validate` parameter. Return an error string to block submission, or `None` to allow it.
+
+```python
+group_by_form = mo.ui.dropdown(
+    options=df_columns,
+    label="Select column to filter for duplicate analyzis",
+    allow_select_none=True,
+    value=None,  # start with nothing selected
+    searchable=True,
+).form(
+    submit_button_label="Apply",
+    validate=lambda v: (
+        "Please select a column and press Apply."
+        if v is None else None
+    ),
+)
+```
+
+However, the user may also want to use other components. Popular alternatives include the `ScatterWidget` from the `drawdata` library, `moutils`, and `wigglystuff`. 
 
 For custom classes and static HTML representations you can also use the `_display_` method. 
 

--- a/.claude/skills/implement-paper
+++ b/.claude/skills/implement-paper
@@ -1,0 +1,1 @@
+../../.agents/skills/implement-paper

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "skills": {
+    "anywidget-generator": {
+      "source": "marimo-team/skills",
+      "sourceType": "github",
+      "computedHash": "7c8e9683f6ba53ed3079e1a6e28d81c7397104fb7f8eedd983eb968597a1714c"
+    },
+    "implement-paper": {
+      "source": "marimo-team/skills",
+      "sourceType": "github",
+      "computedHash": "f08d521800f34c952012f306e5429bb1e87527432566273083ea9f1bc96897e7"
+    },
+    "marimo-batch": {
+      "source": "marimo-team/skills",
+      "sourceType": "github",
+      "computedHash": "b697e72139093c633f2b34b56e0b02c69c5ebff53e4ebdd3c0fbe033a2af5f84"
+    },
+    "marimo-notebook": {
+      "source": "marimo-team/skills",
+      "sourceType": "github",
+      "computedHash": "078d832027a1811df696632b4fc8342ecf251d9f584339359abfee340a1fa195"
+    }
+  }
+}


### PR DESCRIPTION
Add new implement-paper skill with support for fetching research papers and generating anywidget components. Expand marimo-notebook skill with comprehensive references for deployment, exports, pytest, state management, and anywidget integration. Update existing references for SQL, UI, and top-level imports with marimo-batch skill documentation updates.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>