### PR TITLE
Add dark mode support to RPSLS widget

### DIFF
--- a/rpsls_widget/rpsls_widget.css
+++ b/rpsls_widget/rpsls_widget.css
@@ -1,7 +1,23 @@
 .rpsls-container {
+  --rpsls-node-stroke: #fff;
+  --rpsls-label-fill: #333;
+  --rpsls-edge-color: #888;
+  --rpsls-edge-dim: #e0e0e0;
+  --rpsls-arrow-fill: #666;
+
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+@media (prefers-color-scheme: dark) {
+  .rpsls-container {
+    --rpsls-node-stroke: #333;
+    --rpsls-label-fill: #ddd;
+    --rpsls-edge-color: #999;
+    --rpsls-edge-dim: #444;
+    --rpsls-arrow-fill: #999;
+  }
 }
 
 .rpsls-container svg {
@@ -11,6 +27,7 @@
 .node-label {
   font-size: 13px;
   font-weight: 600;
+  fill: var(--rpsls-label-fill);
   pointer-events: none;
   user-select: none;
 }
@@ -21,7 +38,7 @@
 }
 
 .node-circle {
-  stroke: #fff;
+  stroke: var(--rpsls-node-stroke);
   stroke-width: 2;
 }
 

--- a/rpsls_widget/rpsls_widget.js
+++ b/rpsls_widget/rpsls_widget.js
@@ -61,6 +61,12 @@ function render({ model, el }) {
     .attr("height", height)
     .attr("viewBox", `0 0 ${width} ${height}`);
 
+  // Read CSS custom properties for theming
+  const cs = getComputedStyle(container);
+  const edgeColor = cs.getPropertyValue("--rpsls-edge-color").trim() || "#888";
+  const edgeDim = cs.getPropertyValue("--rpsls-edge-dim").trim() || "#e0e0e0";
+  const arrowFill = cs.getPropertyValue("--rpsls-arrow-fill").trim() || "#666";
+
   const defs = svg.append("defs");
 
   const edgeGroup = svg.append("g");
@@ -78,7 +84,7 @@ function render({ model, el }) {
     const refX = nodeRadius / 1.4 + 10;
 
     const markerConfigs = [
-      { id: "arrowhead", fill: "#666" },
+      { id: "arrowhead", fill: arrowFill },
       { id: "arrowhead-red", fill: "#e74c3c" },
       { id: "arrowhead-beats", fill: "#27ae60" },
       { id: "arrowhead-loses", fill: "#e67e22" },
@@ -208,7 +214,7 @@ function render({ model, el }) {
         .attr("y1", (d) => d.y1)
         .attr("x2", (d) => d.x2)
         .attr("y2", (d) => d.y2)
-        .attr("stroke", (d) => (d.isExtra ? "#e74c3c" : "#888"))
+        .attr("stroke", (d) => (d.isExtra ? "#e74c3c" : edgeColor))
         .attr("stroke-width", strokeWidth)
         .attr("stroke-opacity", 1);
 
@@ -231,7 +237,7 @@ function render({ model, el }) {
         .attr("y1", (d) => d.y1)
         .attr("x2", (d) => d.x2)
         .attr("y2", (d) => d.y2)
-        .attr("stroke", (d) => (d.isExtra ? "#e74c3c" : "#888"))
+        .attr("stroke", (d) => (d.isExtra ? "#e74c3c" : edgeColor))
         .attr("stroke-width", strokeWidth)
         .attr("stroke-opacity", 1);
     }
@@ -298,7 +304,7 @@ function render({ model, el }) {
         .attr("stroke", (d) => {
           if (d.source === idx) return "#27ae60";
           if (d.target === idx) return "#e67e22";
-          return "#e0e0e0";
+          return edgeDim;
         })
         .attr("stroke-width", (d) =>
           d.source === idx || d.target === idx ? strokeWidth * 2 : strokeWidth * 0.5
@@ -340,7 +346,7 @@ function render({ model, el }) {
       const applyLabels = animate ? allLabels.transition().duration(dur) : allLabels;
 
       applyLines
-        .attr("stroke", (d) => (d.isExtra ? "#e74c3c" : "#888"))
+        .attr("stroke", (d) => (d.isExtra ? "#e74c3c" : edgeColor))
         .attr("stroke-width", strokeWidth);
 
       allLines


### PR DESCRIPTION
## Summary
- Adds CSS custom properties for all theme-sensitive colors (node stroke, label fill, edge colors, arrowhead fill)
- Uses `@media (prefers-color-scheme: dark)` to swap to dark-friendly values
- JS reads CSS variables via `getComputedStyle` instead of hardcoding colors

## Test plan
- [ ] Open the RPSLS notebook in light mode and verify the widget looks unchanged
- [ ] Switch to dark mode and verify labels, edges, and node strokes adapt

🤖 Generated with [Claude Code](https://claude.com/claude-code)