### PR TITLE
Fix RPSLS widget arc direction and marker rendering

### DIFF
--- a/rpsls-math.py
+++ b/rpsls-math.py
@@ -4,6 +4,7 @@
 #     "anywidget>=0.9.0",
 #     "marimo",
 #     "traitlets>=5.0.0",
+#     "wigglystuff==0.2.37",
 # ]
 # ///
 
@@ -46,8 +47,8 @@ def _(RpslsWidget, mo):
 
 
 @app.cell
-def _(widget):
-    widget.animate_highlight("A")
+def _():
+    # widget.animate_highlight("A")
     return
 
 
@@ -58,8 +59,8 @@ def _(widget):
 
 
 @app.cell
-def _(mo, widget):
-    mo.vstack([widget])
+def _(widget):
+    widget
     return
 
 

--- a/rpsls-math.py
+++ b/rpsls-math.py
@@ -40,15 +40,9 @@ def _(mo):
 
 
 @app.cell
-def _(RpslsWidget, mo, slider):
-    widget = mo.ui.anywidget(RpslsWidget(n=slider.value))
+def _(RpslsWidget, mo):
+    widget = mo.ui.anywidget(RpslsWidget(n=3))
     return (widget,)
-
-
-@app.cell
-def _(mo):
-    slider = mo.ui.slider(3, 45, value=5, label="Number of elements (n)", show_value=True)
-    return (slider,)
 
 
 @app.cell
@@ -64,14 +58,8 @@ def _(widget):
 
 
 @app.cell
-def _(mo, slider, widget):
-    mo.vstack([slider, widget])
-    return
-
-
-@app.cell(hide_code=True)
-def _(widget):
-    widget
+def _(mo, widget):
+    mo.vstack([widget])
     return
 
 

--- a/rpsls-math.py
+++ b/rpsls-math.py
@@ -47,26 +47,59 @@ def _(RpslsWidget, mo):
 
 
 @app.cell
-def _():
-    # widget.animate_highlight("A")
-    return
-
-
-@app.cell
-def _(widget):
-    widget.animate_node(1)
-    return
-
-
-@app.cell
 def _(widget):
     widget
     return
 
 
 @app.cell
-def _():
+def _(mo):
+    from wigglystuff import KeystrokeWidget
+
+    keystroke = mo.ui.anywidget(KeystrokeWidget())
+    keystroke
+    return (keystroke,)
+
+
+@app.cell
+def _(keystroke):
+    keystroke.last_key["key"]
     return
+
+
+@app.cell
+def _(get_highlight, keystroke, set_highlight, widget):
+    names = "abcdefghijklmnopqrstuvwxyz".upper()
+
+    if keystroke.last_key["key"] == "ArrowRight":
+        widget.animate_node(1)
+        set_highlight(-1)
+    if keystroke.last_key["key"] == "ArrowLeft":
+        widget.animate_node(-1)
+        set_highlight(-1)
+    if keystroke.last_key["key"] == "ArrowUp":
+        set_highlight(lambda _: (_ + 1) % widget.n)
+    if keystroke.last_key["key"] == "ArrowDown":
+        set_highlight(lambda _: (_ - 1) % widget.n)
+    if keystroke.last_key["key"] == "q":
+        set_highlight(-1)
+        widget.clear_highlight()
+
+    if get_highlight() >= 0:
+        widget.animate_highlight(names[get_highlight()])
+    return
+
+
+@app.cell
+def _(get_highlight):
+    get_highlight()
+    return
+
+
+@app.cell
+def _(mo):
+    get_highlight, set_highlight = mo.state(-1)
+    return get_highlight, set_highlight
 
 
 if __name__ == "__main__":

--- a/rpsls_widget/rpsls_widget.css
+++ b/rpsls_widget/rpsls_widget.css
@@ -4,6 +4,7 @@
   --rpsls-edge-color: #888;
   --rpsls-edge-dim: #e0e0e0;
   --rpsls-arrow-fill: #666;
+  --rpsls-highlight-stroke: #555;
 
   display: flex;
   justify-content: center;
@@ -17,6 +18,7 @@
     --rpsls-edge-color: #999;
     --rpsls-edge-dim: #444;
     --rpsls-arrow-fill: #999;
+    --rpsls-highlight-stroke: #ccc;
   }
 }
 

--- a/rpsls_widget/rpsls_widget.js
+++ b/rpsls_widget/rpsls_widget.js
@@ -1,12 +1,6 @@
 import * as d3 from "https://esm.sh/d3@7";
 
-const NAMES = {
-  3: ["Rock", "Paper", "Scissors"],
-  5: ["Rock", "Paper", "Scissors", "Lizard", "Spock"],
-};
-
 function getNames(n) {
-  if (NAMES[n]) return NAMES[n];
   return Array.from({ length: n }, (_, i) => String.fromCharCode(65 + i));
 }
 
@@ -17,7 +11,7 @@ function buildTournament(n) {
 
   for (let i = 0; i < n; i++) {
     for (let j = 1; j <= k; j++) {
-      edges.push({ source: i, target: (i + j) % n });
+      edges.push({ source: (i + j) % n, target: i });
     }
   }
 
@@ -27,9 +21,9 @@ function buildTournament(n) {
       const opposite = i + n / 2;
       // Alternate direction to spread imbalance
       if (i % 2 === 0) {
-        edges.push({ source: i, target: opposite });
-      } else {
         edges.push({ source: opposite, target: i });
+      } else {
+        edges.push({ source: i, target: opposite });
       }
     }
   }
@@ -176,9 +170,14 @@ function render({ model, el }) {
     let exitCount = 0;
     const exitTotal = exitingLines.size();
     exitingLines
+      .attr("marker-end", null)
       .transition()
       .duration(edgeDur)
       .attr("stroke-opacity", 0)
+      .attr("x1", topX)
+      .attr("y1", topY)
+      .attr("x2", topX)
+      .attr("y2", topY)
       .remove()
       .on("end", () => {
         exitCount++;
@@ -199,7 +198,10 @@ function render({ model, el }) {
 
     const allLines = linesEnter.merge(lines).attr("class", "edge");
 
-    allLines
+    // Set marker-end only on existing (updating) lines — entering lines
+    // are collapsed to a point so markers would be visible at 12 o'clock.
+    // Entering lines get their markers in animateNewEdges().
+    lines
       .attr("stroke-dasharray", (d) => (d.isExtra ? "5,4" : "none"))
       .attr("marker-end", (d) =>
         d.isExtra ? "url(#arrowhead-red)" : "url(#arrowhead)"
@@ -231,6 +233,10 @@ function render({ model, el }) {
         .attr("y2", newestNode.y);
 
       linesEnter
+        .attr("stroke-dasharray", (d) => (d.isExtra ? "5,4" : "none"))
+        .attr("marker-end", (d) =>
+          d.isExtra ? "url(#arrowhead-red)" : "url(#arrowhead)"
+        )
         .transition()
         .duration(edgeDur)
         .attr("x1", (d) => d.x1)

--- a/rpsls_widget/rpsls_widget.js
+++ b/rpsls_widget/rpsls_widget.js
@@ -60,6 +60,7 @@ function render({ model, el }) {
   const edgeColor = cs.getPropertyValue("--rpsls-edge-color").trim() || "#888";
   const edgeDim = cs.getPropertyValue("--rpsls-edge-dim").trim() || "#e0e0e0";
   const arrowFill = cs.getPropertyValue("--rpsls-arrow-fill").trim() || "#666";
+  const highlightStroke = cs.getPropertyValue("--rpsls-highlight-stroke").trim() || "#555";
 
   const defs = svg.append("defs");
 
@@ -220,6 +221,24 @@ function render({ model, el }) {
         .attr("stroke-width", strokeWidth)
         .attr("stroke-opacity", 1);
 
+      // When shrinking, new edges from topology change also need to animate in
+      if (shrinking && linesEnter.size() > 0) {
+        linesEnter
+          .attr("stroke-dasharray", (d) => (d.isExtra ? "5,4" : "none"))
+          .attr("marker-end", (d) =>
+            d.isExtra ? "url(#arrowhead-red)" : "url(#arrowhead)"
+          )
+          .transition()
+          .duration(nodeDur)
+          .attr("x1", (d) => d.x1)
+          .attr("y1", (d) => d.y1)
+          .attr("x2", (d) => d.x2)
+          .attr("y2", (d) => d.y2)
+          .attr("stroke", (d) => (d.isExtra ? "#e74c3c" : edgeColor))
+          .attr("stroke-width", strokeWidth)
+          .attr("stroke-opacity", 1);
+      }
+
       moveNodes();
     }
 
@@ -330,13 +349,16 @@ function render({ model, el }) {
       // Raise connected edges above dimmed ones in the DOM
       allLines.filter((d) => d.source === idx || d.target === idx).raise();
 
-      // Dim unrelated nodes
-      applyCircles.attr("opacity", (d, i) => {
-        const connected = edgeDataMarked.some(
-          (e) => (e.source === idx && e.target === i) || (e.target === idx && e.source === i)
-        );
-        return i === idx || connected ? 1 : 0.3;
-      });
+      // Dim unrelated nodes, highlight selected node border
+      applyCircles
+        .attr("opacity", (d, i) => {
+          const connected = edgeDataMarked.some(
+            (e) => (e.source === idx && e.target === i) || (e.target === idx && e.source === i)
+          );
+          return i === idx || connected ? 1 : 0.3;
+        })
+        .style("stroke", (d, i) => (i === idx ? highlightStroke : null))
+        .style("stroke-width", (d, i) => (i === idx ? "4px" : null));
       applyLabels.attr("opacity", (d, i) => {
         const connected = edgeDataMarked.some(
           (e) => (e.source === idx && e.target === i) || (e.target === idx && e.source === i)
@@ -360,7 +382,7 @@ function render({ model, el }) {
         .attr("marker-end", (d) =>
           d.isExtra ? "url(#arrowhead-red)" : "url(#arrowhead)"
         );
-      applyCircles.attr("opacity", 1);
+      applyCircles.attr("opacity", 1).style("stroke", null).style("stroke-width", null);
       applyLabels.attr("opacity", 1);
     }
 

--- a/rpsls_widget/rpsls_widget.py
+++ b/rpsls_widget/rpsls_widget.py
@@ -53,3 +53,13 @@ class RpslsWidget(anywidget.AnyWidget):
             self.highlighted_node = ""
         else:
             self.highlighted_node = name
+
+    def clear_highlight(self, duration=400):
+        """Remove any active node highlight.
+
+        Args:
+            duration: Animation duration in milliseconds.
+        """
+        self._node_duration = duration
+        self._edge_duration = duration
+        self.highlighted_node = ""


### PR DESCRIPTION
## Summary
- Reversed edge directions so arcs point from the node that beats to the node that loses (Rock→Scissors, not Rock→Paper)
- Replaced hardcoded Rock/Paper/Scissors/Lizard/Spock names with generic A/B/C/D labels
- Fixed lingering arrowhead markers when incrementing/decrementing nodes by removing markers before exit animation and deferring them until entering lines animate in

## Test
- Widget displays correct beat relationships when hovering nodes
- No arrowhead markers linger at 12 o'clock during increment/decrement animations
- Generic labels work correctly for any n value

🤖 Generated with [Claude Code](https://claude.com/claude-code)