### PR TITLE
Add randopt notebooks and marimo-pair skill

### DIFF
--- a/.agents/skills/marimo-pair/README.md
+++ b/.agents/skills/marimo-pair/README.md
@@ -1,0 +1,46 @@
+# marimo-pair
+
+> [!WARNING]
+> Experimental agent skill for pair programming in [marimo](https://marimo.io)
+> notebooks. Expect rough edges.
+
+## Prerequisites
+
+- A running [marimo](https://marimo.io) notebook (started with
+  `--no-token --no-skew-protection`)
+- `bash`, `curl`, and `jq` available on `PATH`
+
+## Install
+
+### Agent Skills (any tool)
+
+Works with any agent that supports the [Agent Skills](https://agentskills.io)
+open standard:
+
+```bash
+npx skills add marimo-team/marimo-pair
+
+# or upgrade an existing install
+npx skills upgrade marimo-team/marimo-pair
+```
+
+If you don't have `npx` installed but have `uv`:
+
+```bash
+uvx deno -A npm:skills add marimo-team/marimo-pair
+```
+
+### Claude Code (plugin)
+
+Add the marketplace and install the plugin:
+
+```
+/plugin marketplace add marimo-team/marimo-pair
+/plugin install marimo-pair@marimo-team-marimo-pair
+```
+
+To opt in to auto-updates (recommended), so you always get the latest version:
+
+```
+/plugin → Marketplaces → marimo-team-marimo-pair → Enable auto-update
+```

--- a/.agents/skills/marimo-pair/SKILL.md
+++ b/.agents/skills/marimo-pair/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: marimo-pair
+description: >-
+  Collaboration protocol for pairing with a user through a running marimo
+  notebook via bundled scripts or MCP. Use when the user asks you to work in,
+  build, explore, or modify a marimo notebook — or when you detect a running
+  marimo session by listing sessions. Do NOT use for general Python scripting
+  outside of marimo or for marimo plugin/package development.
+---
+
+# marimo Pair Programming Protocol
+
+This skill gives you full access to a running marimo notebook. You can read
+cell code, create and edit cells, install packages, run cells, and inspect
+the reactive graph — all programmatically. The user sees results live in their
+browser while you work through bundled scripts or MCP.
+
+## Philosophy
+
+marimo notebooks are a dataflow graph — cells are the fundamental unit of
+computation, connected by the variables they define and reference. When a cell
+runs, marimo automatically re-executes downstream cells. You have full access
+to the running notebook.
+
+- **Cells are your main lever.** Use them to break up work and choose how and
+  when to bring the human into the loop. Not every cell needs rich output —
+  sometimes the object itself is enough, sometimes a summary is better.
+  Match the presentation to the intent.
+- **Understand intent first.** When clear, act. When ambiguous, clarify.
+- **Follow existing signal.** Check imports, `pyproject.toml`, existing cells,
+  and `dir(ctx)` before reaching for external tools.
+- **Stay focused.** Build first, polish later — cell names, layout, and styling
+  can wait.
+
+## Prerequisites
+
+The marimo server must be running with token and skew protection disabled.
+
+### How to invoke marimo
+
+marimo must be invoked with `--no-token --no-skew-protection` to be
+discoverable. The right way to invoke it depends on context (project tooling,
+global install, sandbox mode). See
+[finding-marimo.md](reference/finding-marimo.md) for the full decision tree.
+
+**Do NOT use `--headless` unless the user asks for it.** Omitting it lets
+marimo auto-open the browser, which is the expected pairing experience. If the
+user explicitly requests headless, offer to open it with
+`open http://localhost:<port>`.
+
+## How to Discover Servers and Execute Code
+
+Two operations: **discover servers** and **execute code**.
+
+| Operation | Script | MCP |
+|-----------|--------|-----|
+| Discover servers | `bash scripts/discover-servers.sh` | `list_sessions()` tool |
+| Execute code | `bash scripts/execute-code.sh -c "code"` | `execute_code(code=..., session_id=...)` tool |
+| Execute code (complex) | `bash scripts/execute-code.sh /tmp/code.py` | same |
+
+Scripts auto-discover sessions from the registry on disk. Use `--port` to
+target a specific server when multiple are running. If the server was started
+with `--mcp`, you'll have MCP tools available as an alternative.
+
+### No servers running?
+
+**Always discover before starting.** Background task "completed" notifications
+do not mean the server died — check the output or run discover first.
+
+If no servers are found, read the user's intent — if they want a notebook,
+start one. See [finding-marimo.md](reference/finding-marimo.md).
+
+If there's no `.py` file yet, pick a descriptive filename based on context
+(e.g., `exploration.py`, `analysis.py`, `dashboard.py`). Don't ask — just
+pick something reasonable.
+
+**Use a file for complex code.** When code contains quotes, backticks,
+`${}` template literals, or multiline strings (common with anywidget ESM
+modules), write the code to a temp file with the Write tool first, then pass
+the file path as a positional argument. This avoids shell escaping issues
+entirely. Write temp files under `/tmp/mo-<id>/` where `<id>` is a short
+random ID you pick once per session, to avoid collisions with stale files
+from other sessions.
+
+**Inline ESM in cell code.** Temp files are for `execute-code.sh` transport
+only — never for runtime. Use `"""` for ESM inside `'''` for the cell code.
+
+## Executing Code
+
+Every execute-code call runs inside the notebook's kernel. All cell variables
+are in scope — `print(df.head())` just works. Nothing you define persists
+between calls (variables, imports, side-effects all reset), but you can freely
+introspect the notebook: inspect variables, test code snippets, check types
+and shapes. Use this to explore, prototype, and validate before committing
+anything to the notebook — then create cells to persist state and make results
+visible to the user.
+
+To mutate the notebook's dataflow graph — create, edit, and delete cells,
+install packages, and run cells — use `marimo._code_mode`:
+
+```python
+import marimo._code_mode as cm
+
+async with cm.get_context() as ctx:
+    cid = ctx.create_cell("x = 1")
+    ctx.install_packages("pandas")
+    ctx.run_cell(cid)
+```
+
+You **must** use `async with` — without it, operations silently do nothing.
+All `ctx.*` methods are **synchronous** — they queue operations and the
+context manager flushes them on exit. Do **not** `await` them.
+
+**Cells are not auto-executed.** `create_cell` and `edit_cell` are structural
+changes only — use `run_cell` to queue execution.
+
+`code_mode` is a tested, safe API for notebook mutations — prefer it for all
+structural changes. You also have access to marimo internals from the kernel,
+but treat that as a last resort and only with high confidence after exploration.
+
+**UI state lives outside the reactive graph.** Anywidget traitlets can be read
+or set directly (e.g., `slider.value = 5`). For `mo.ui.*` elements, use
+`ctx.set_ui_value(element, new_value)` inside `code_mode`.
+
+### First Step: Explore the API
+
+The `code_mode` API can change between marimo versions — and each running
+server could be a different version. Inspect what's available at the start of
+each session, especially when switching between servers.
+
+```python
+import marimo._code_mode as cm
+
+async with cm.get_context() as ctx:
+    ctx  # inspect me — dir(), help(), .cells, ...
+```
+
+## Guard Rails
+
+Skip these and the UI breaks:
+
+- **Install packages via `ctx.install_packages()`, not `uv add` or `pip`.**
+  The code API handles kernel restarts and dependency resolution correctly.
+  Only fall back to external CLIs if the API is unavailable or fails.
+- **Custom widget = anywidget.** For bespoke visual components, use anywidget
+  with HTML/CSS/JS. Composed `mo.ui` is fine for simple forms and controls.
+  See [rich-representations.md](reference/rich-representations.md).
+- **NEVER write to the `.py` file directly while a session is running — the kernel owns it.**
+- **No temp-file deps in cells.** `pathlib.Path("/tmp/...")` in cell code is a bug.
+- **Avoid empty cells.** Prefer `edit_cell` into existing empty cells rather
+  than creating new ones. Clean up any cells that end up empty after edits.
+- **Don't worry about cell names.** Most cells don't need explicit names —
+  see [notebook-improvements.md](reference/notebook-improvements.md#cell-names).
+
+## Widgets and Reactivity
+
+Anywidget state (traitlets) lives outside marimo's reactive graph. To hook a
+widget trait into the graph, pick one strategy per widget — never mix them:
+
+- **`mo.state` + `.observe()`** — you pick specific traits to bridge. Default choice.
+- **`mo.ui.anywidget()`** — wraps all synced traits into one reactive `.value`. Convenient but coarser.
+
+Read [rich-representations.md](reference/rich-representations.md) before wiring either.
+
+## Keep in Mind
+
+- **The user is editing too.** The notebook can change between your calls —
+  re-inspect notebook state if it's been a while since you last looked.
+- **Deletions are destructive.** Deleting a cell removes its variables from
+  kernel memory — restoring means recreating the cell and re-running it and
+  its dependents. If intent seems ambiguous, ask first.
+- **Installing packages changes the project.** `ctx.install_packages()` adds
+  real dependencies — confirm when it's not obvious from context.
+
+## References
+
+- [finding-marimo.md](reference/finding-marimo.md) — how to find and invoke the right marimo
+- [gotchas.md](reference/gotchas.md) — cached module proxies and other traps
+- [rich-representations.md](reference/rich-representations.md) — custom widgets and visualizations
+- [notebook-improvements.md](reference/notebook-improvements.md) — improving existing notebooks

--- a/.agents/skills/marimo-pair/reference/finding-marimo.md
+++ b/.agents/skills/marimo-pair/reference/finding-marimo.md
@@ -1,0 +1,68 @@
+# Finding and Invoking marimo
+
+marimo must be invoked with these flags to be discoverable by this skill:
+
+```sh
+marimo edit notebook.py --no-token --no-skew-protection [--sandbox]
+```
+
+How you invoke `marimo` depends on context — find the right way to run it.
+
+## Inside a Python project
+
+If there's a `pyproject.toml` in cwd or a parent directory, check that marimo
+is actually in the dependencies before using the project's runner. Look for
+`marimo` in:
+
+- `[project.dependencies]`
+- `[project.optional-dependencies]` or `[dependency-groups]` (dev deps)
+- `[tool.pixi.dependencies]`
+- The project's `.venv` (`uv pip show marimo` or check `.venv/bin/marimo`)
+
+If marimo is in a named dependency group (not the default), you need to
+specify it:
+
+```sh
+# marimo is in [dependency-groups] → "notebooks" group
+uv run --group notebooks marimo edit notebook.py --no-token --no-skew-protection
+```
+
+Once you know marimo is available, use whatever CLI runner the project uses:
+
+```sh
+# uv-managed project
+uv run marimo edit notebook.py --no-token --no-skew-protection
+
+# pixi-managed project
+pixi run marimo edit notebook.py --no-token --no-skew-protection
+```
+
+Skip `--sandbox` here — the project already manages dependencies.
+
+If `pyproject.toml` exists but marimo is **not** in the deps, treat this as
+"outside a project" (see below).
+
+## Outside a Python project
+
+Prefer `--sandbox`. Sandbox mode creates an isolated environment for the
+notebook and writes dependencies into the script itself as inline PEP 723
+metadata — so the notebook stays self-contained and reproducible.
+
+```sh
+# With uv available (preferred)
+uvx marimo@latest edit notebook.py --no-token --no-skew-protection --sandbox
+
+# With marimo installed globally
+marimo edit notebook.py --no-token --no-skew-protection --sandbox
+```
+
+## Global marimo install
+
+If marimo is installed globally, check the version — code mode shipped in
+v0.21.1. If the installed version is older, prompt the user to upgrade before
+proceeding.
+
+## Nothing found
+
+If no project marimo, no `uv`/`uvx`, and no global `marimo` on PATH, tell the
+user to install `uv` (`curl -LsSf https://astral.sh/uv/install.sh | sh`).

--- a/.agents/skills/marimo-pair/reference/gotchas.md
+++ b/.agents/skills/marimo-pair/reference/gotchas.md
@@ -1,0 +1,24 @@
+# Gotchas
+
+## Cached module availability
+
+Some libraries cache optional-dependency availability at import time. Installing
+a package mid-session via `ctx.install_packages()` won't update those caches.
+The user may need to restart the kernel — but try known workarounds first.
+
+### Polars + pyarrow
+
+`df.to_pandas()` fails with `ModuleNotFoundError: pa.Table requires 'pyarrow'`.
+
+**Workaround** — if this error occurs after installing pyarrow mid-session,
+run the following via `execute-code` (scratchpad), NOT in a cell. The patch
+mutates the cached module object in the running kernel, so it doesn't need to
+persist in the notebook.
+
+```python
+import pyarrow as _pa
+import polars.dataframe.frame as _frame_mod
+_frame_mod.pa = _pa
+```
+
+Then re-run the failing cell.

--- a/.agents/skills/marimo-pair/reference/notebook-improvements.md
+++ b/.agents/skills/marimo-pair/reference/notebook-improvements.md
@@ -1,0 +1,91 @@
+# Notebook Improvements
+
+When the user asks to improve, optimize, or clean up their notebook, scan the
+current cells for these opportunities. Use your judgment — don't over-apply,
+and if you're unsure whether a change is worthwhile, ask the user.
+
+## Cell names
+
+Low priority unless the user asks. `setup` and cells defining
+functions/classes are auto-named by marimo. Beyond that, naming is optional.
+Note that naming markdown cells clutters the UI by showing the cell header
+that's normally hidden.
+
+## Setup cell
+
+A setup cell is named `"setup"` and is guaranteed to run before all other
+cells. It's the place for module imports. Consolidating imports here keeps
+the notebook clean and ensures every cell can rely on those modules being
+available.
+
+First check if the notebook already has a cell named `"setup"`. If not,
+create one and hoist scattered imports into it:
+
+```python
+cid = ctx.create_cell('''import polars as pl
+import marimo as mo
+import anywidget
+import traitlets''', name="setup")
+ctx.run_cell(cid)
+```
+
+If a setup cell already exists, use `ctx.edit_cell("setup", code=...)` and
+`ctx.run_cell("setup")` to modify and re-run it.
+
+## Lift reusable functions into their own cells
+
+When a cell contains a single function or class that doesn't reference
+variables from other cells, marimo treats it specially — it can be written as
+a standalone definition and reused outside the notebook. These functions can
+use modules from the setup cell.
+
+Look for functions that **could belong in a library**: data loading, transforms,
+parsers, domain logic, custom widgets. If someone might reasonably `import` it
+from another module, it's a good candidate to lift into its own cell.
+
+Don't lift everything — notebook-specific wiring (UI layout, display logic,
+cell-level orchestration) should stay where it is. Use `_prefix` for
+cell-internal helpers that aren't meant to be reused.
+
+```python
+# before: useful logic buried in a larger cell
+objects = pl.read_csv("https://example.com/objects.csv")
+artists = pl.read_csv("https://example.com/artists.csv")
+
+def top_counts(df, col, n=5):
+    return df.group_by(col).len().sort("len", descending=True).head(n)
+
+result = top_counts(objects.join(artists, on="id"), "category")
+```
+
+```python
+# after: top_counts is general-purpose — give it its own cell
+
+# cell 1
+def top_counts(df, col, n=5):
+    return df.group_by(col).len().sort("len", descending=True).head(n)
+```
+
+```python
+# cell 2
+result = top_counts(df, "category")
+```
+
+## `mo.persistent_cache`
+
+`@mo.persistent_cache` caches a function's result to disk so it isn't
+recomputed on subsequent runs. The cache persists across kernel restarts.
+
+```python
+@mo.persistent_cache
+def load_data():
+    objects = pl.read_csv("https://example.com/objects.csv")
+    artists = pl.read_csv("https://example.com/artists.csv")
+    return objects.join(artists, on="id", how="left")
+
+df = load_data()
+```
+
+Good candidates: data loading, ETL, expensive computation that rarely changes.
+Don't over-optimize — if you're unsure, suggest it to the user rather than
+applying it.

--- a/.agents/skills/marimo-pair/reference/rich-representations.md
+++ b/.agents/skills/marimo-pair/reference/rich-representations.md
@@ -1,0 +1,302 @@
+# Rich Representations
+
+Custom visual encodings for data that go beyond standard charts and tables.
+
+## Guiding principles
+
+**Visualization matters.** Helping users build custom visual representations
+is one of the highest-impact things the agent can do. A bespoke encoding
+tailored to the task — labeling, batch review, comparing variants — lets
+users *see* their data in ways that tables and numbers never will. marimo
+is an environment where users create their own views, not just consume
+library charts. Help them imagine what's possible, then build it.
+
+**Use the modern web.** Always use the most modern HTML, CSS, and JavaScript
+available. If a feature is supported in every browser, even if only the most
+recent version, use it.
+
+**Prefer compact output.** marimo clips cell output at ~610px and scrolls.
+Avoid hitting that limit; if you need more space, manage your own scrolling
+inside a fixed-height container.
+
+**Keep it thin, make it compose.** A widget is a thin layer over data, not
+an application. One clear purpose, few traitlets, small `_esm`. Build small
+pieces that compose in the notebook — combine with other cells, UI elements,
+and views. Don't over-engineer.
+
+## Decision tree
+
+| Need | Approach |
+|------|----------|
+| Default for any custom output | **anywidget** — even display-only; you get layout control and can add interaction later |
+| Trivial one-off static HTML | `_display_()` or `mo.Html` — only when an anywidget is truly overkill |
+| Single built-in control used as-is (slider, dropdown) | `mo.ui.*` |
+
+When in doubt, build an anywidget.
+
+## anywidget
+
+[anywidget](https://anywidget.dev) bridges Python and JavaScript via
+traitlets. `.tag(sync=True)` makes a traitlet bidirectional — Python sets a
+value → JS sees it; JS calls `model.set()` + `model.save_changes()` →
+Python sees it. `_css` is optional global CSS.
+
+**marimo does not render traditional Jupyter widgets.** Libraries like jscatter,
+ipyvolume, etc. often have a top-level object whose default representation is a
+Jupyter widget (`application/vnd.jupyter.widget-view+json`). marimo cannot
+display these — you need to find the underlying **anywidget** instance, which
+marimo *does* support.
+
+Common pattern: look for a `.widget` attribute on the library object:
+
+```python
+# jscatter example — Scatter is not renderable, but .widget is an anywidget
+scatter = jscatter.Scatter(data=df, x="x", y="y")
+scatter.widget  # <-- use this in the cell output
+```
+
+When unsure, check in the scratchpad:
+
+```python
+import anywidget
+obj = scatter.widget  # or whatever accessor the library provides
+print(isinstance(obj, anywidget.AnyWidget))  # True = marimo can render it
+```
+
+### `_esm` lifecycle
+
+**Render only** (most widgets):
+
+```js
+function render({ model, el }) { /* ... */ }
+export default { render };
+```
+
+**Initialize + render** (shared state across views, one-time setup):
+
+```js
+export default () => {
+  return {
+    initialize({ model }) {
+      // Once per widget instance — timers, connections, shared handlers
+      return () => { /* cleanup */ };
+    },
+    render({ model, el }) {
+      // Once per view — display in 3 cells = 3 renders
+      return () => { /* cleanup DOM listeners */ };
+    }
+  };
+};
+```
+
+- `model.on()` is auto-cleaned when a view is removed
+- DOM `addEventListener` is **not** — clean up with `AbortController`
+
+### Timer example (initialize + render)
+
+`initialize` owns one interval; each `render` view displays it.
+
+```python
+import anywidget
+import traitlets
+
+_TIMER_ESM = """
+export default () => {
+  return {
+    initialize({ model }) {
+      const id = setInterval(() => {
+        if (model.get("running")) {
+          model.set("seconds", model.get("seconds") + 1);
+          model.save_changes();
+        }
+      }, 1000);
+      return () => clearInterval(id);
+    },
+    render({ model, el }) {
+      const controller = new AbortController();
+      const { signal } = controller;
+
+      const span = document.createElement("span");
+      span.style.cssText = "font: 24px monospace;";
+
+      const btn = document.createElement("button");
+      btn.style.cssText = "margin-left: 8px; cursor: pointer;";
+
+      function update() {
+        const s = model.get("seconds");
+        const mm = String(Math.floor(s / 60)).padStart(2, "0");
+        const ss = String(s % 60).padStart(2, "0");
+        span.textContent = `${mm}:${ss}`;
+        btn.textContent = model.get("running") ? "⏸" : "▶";
+      }
+
+      model.on("change:seconds", update);
+      model.on("change:running", update);
+
+      btn.addEventListener("click", () => {
+        model.set("running", !model.get("running"));
+        model.save_changes();
+      }, { signal });
+
+      update();
+      el.append(span, btn);
+      return () => controller.abort();
+    }
+  };
+};
+"""
+
+class Timer(anywidget.AnyWidget):
+    seconds = traitlets.Int(0).tag(sync=True)
+    running = traitlets.Bool(True).tag(sync=True)
+    _esm = _TIMER_ESM
+```
+
+### Composing with the notebook
+
+Widgets become reactive notebook citizens when you bridge a traitlet to
+`mo.state`. This is a two-cell pattern — create the widget and wire up the
+observer in one cell, read the value in another:
+
+```python
+# Cell 1 — widget + observer
+timer = Timer()
+
+get_seconds, set_seconds = mo.state(timer.seconds)
+timer.observe(lambda _: set_seconds(timer.seconds), names=["seconds"])
+
+timer  # display the widget
+```
+
+```python
+# Cell 2 — reacts to changes
+seconds = get_seconds()
+mo.md(f"Timer is at **{seconds}s** — {'running' if seconds > 0 else 'stopped'}")
+```
+
+This pattern is always the same: `mo.state(widget.trait)` for the initial
+value, `.observe()` on the specific trait name, read with the getter in a
+downstream cell. See [Reactive anywidgets](#reactive-anywidgets-in-marimo)
+for the full rules.
+
+### CDN dependencies
+
+Import JS libraries from [esm.sh](https://esm.sh) — no build step:
+
+```js
+import * as d3 from "https://esm.sh/d3@7";
+import { tableFromIPC } from "https://esm.sh/@uwdata/flechette@2";
+```
+
+### DataFrames and binary data
+
+**Prefer reducing data on the Python side.** Aggregate, filter, sample —
+send the widget only what it needs. Most widgets should receive a small,
+pre-processed payload via simple traitlets (lists, dicts). This keeps the
+widget simple and avoids extra dependencies.
+
+**For large tabular data (>2k rows)** where the widget genuinely needs
+row-level access, send Arrow IPC bytes instead of JSON. This adds
+complexity and dependencies, so only reach for it when the data volume
+justifies it.
+
+**Python — serialize:**
+
+```python
+# Polars (native, no pyarrow needed)
+_ipc=df.write_ipc(None).getvalue()
+
+# Any __arrow_c_stream__ source (pandas, narwhals, pyarrow, etc.)
+import io, pyarrow as pa, pyarrow.feather as feather
+
+def to_arrow_ipc(data) -> bytes:
+    table = pa.RecordBatchReader.from_stream(data).read_all()
+    sink = io.BytesIO()
+    feather.write_feather(table, sink, compression="uncompressed")
+    return sink.getvalue()
+```
+
+**JS — deserialize with `@uwdata/flechette`:**
+
+```js
+import { tableFromIPC } from "https://esm.sh/@uwdata/flechette@2";
+const table = tableFromIPC(new Uint8Array(model.get("_ipc").buffer));
+// table.numRows, table.numCols, table.get(i), table.getChild("col_name")
+```
+
+Use `traitlets.Any().tag(sync=True)` for the IPC bytes traitlet.
+
+## Reactive anywidgets in marimo
+
+When an anywidget trait (selection, value, zoom, etc.) should drive a
+downstream marimo cell, use `mo.state()` + `.observe()` on the **specific
+trait**. This is the preferred pattern:
+
+```python
+# In the cell that creates the widget:
+get_selection, set_selection = mo.state(widget.selection)
+widget.observe(
+    lambda _: set_selection(widget.selection),
+    names=["selection"],
+)
+
+# In a downstream cell — re-executes when selection changes:
+selection = get_selection()
+```
+
+Initialize `mo.state()` with the widget's current trait value — not a
+hardcoded default. Read the trait directly off the widget in the lambda.
+Do **not** use `change["new"]` or `allow_self_loops=True`.
+
+### `mo.state` + `.observe()` vs `mo.ui.anywidget()`
+
+Two strategies for reactive anywidgets. Choose one per widget — don't mix them.
+
+| Strategy | Reactivity | Best for |
+|----------|-----------|----------|
+| `mo.state` + `.observe()` | Specific traits you pick | Precision — only named traits trigger downstream cells |
+| `mo.ui.anywidget(widget)` | All synced traits as one `.value` dict | Convenience — observe everything at once |
+
+### Programmatic widget control (scratchpad)
+
+Read widget state or set UI controls from the scratchpad — no clicking:
+
+```python
+print(timer.seconds)    # read
+timer.seconds = 0       # set — frontend updates automatically
+```
+
+`mo.ui.*` elements need `set_ui_element_value`; anywidgets use direct
+assignment.
+
+## `_display_()` protocol
+
+Any object with a `_display_()` method renders richly in marimo. Return
+anything marimo can render — `mo.Html`, `mo.md()`, a chart, a string.
+
+Precedence: `_display_()` > built-in formatters > `_mime_()` > IPython
+`_repr_*_()` methods.
+
+```python
+from dataclasses import dataclass
+import marimo as mo
+
+@dataclass
+class ColorSwatch:
+    colors: list[str]
+
+    def _display_(self):
+        divs = "".join(
+            f'<div style="width:40px;height:40px;background:{c};border-radius:4px;"></div>'
+            for c in self.colors
+        )
+        return mo.Html(f'<div style="display:flex;gap:8px;">{divs}</div>')
+```
+
+For inline `<script>` tags, use `document.currentScript.previousElementSibling`
+to scope to the element — never hardcode IDs (breaks with multiple instances).
+
+## Minimize CLS (Cumulative Layout Shift)
+
+Use `min-height` or `aspect-ratio` on the outer container so the widget
+reserves space before content loads or when toggling between states.

--- a/.agents/skills/marimo-pair/scripts/discover-servers.sh
+++ b/.agents/skills/marimo-pair/scripts/discover-servers.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# List running marimo instances from the server registry.
+# Cleans up stale entries (dead PIDs) and outputs live servers as JSON.
+# No marimo installation required.
+set -euo pipefail
+
+# Locate the servers directory
+if [[ "$OSTYPE" == msys* || "$OSTYPE" == cygwin* ]]; then
+  servers_dir="$HOME/.marimo/servers"
+else
+  servers_dir="${XDG_STATE_HOME:-$HOME/.local/state}/marimo/servers"
+fi
+
+if [[ ! -d "$servers_dir" ]]; then
+  echo "[]"
+  exit 0
+fi
+
+results="[]"
+for f in "$servers_dir"/*.json; do
+  [[ -e "$f" ]] || continue
+
+  pid=$(jq -r '.pid' "$f" 2>/dev/null) || continue
+
+  # Clean up stale entries
+  if ! kill -0 "$pid" 2>/dev/null; then
+    rm -f "$f"
+    continue
+  fi
+
+  entry=$(jq '.' "$f" 2>/dev/null) || continue
+  results=$(echo "$results" | jq --argjson e "$entry" '. + [$e]')
+done
+
+echo "$results" | jq .

--- a/.agents/skills/marimo-pair/scripts/execute-code.sh
+++ b/.agents/skills/marimo-pair/scripts/execute-code.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Execute code in a running marimo session's scratchpad.
+# No marimo installation required — talks directly to the HTTP API.
+# Requires the server to be started with --no-token.
+#
+# Usage:
+#   execute-code.sh [--port PORT] -c "code"   # inline code
+#   execute-code.sh [--port PORT] script.py    # code from file
+set -euo pipefail
+
+# Optional eval logging: set EXECUTE_CODE_LOG to a file path to record each call
+if [[ -n "${EXECUTE_CODE_LOG:-}" ]]; then
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$EXECUTE_CODE_LOG"
+fi
+
+port=""
+code=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --port) port="$2"; shift 2 ;;
+    -c)     code="$2"; shift 2 ;;
+    -*)     echo "Unknown option: $1" >&2; exit 1 ;;
+    *)      break ;;
+  esac
+done
+
+if [[ -n "$code" ]]; then
+  : # set via -c
+elif [[ $# -gt 0 ]]; then
+  code=$(cat "$1")
+else
+  echo "Usage: execute-code.sh [--port PORT] -c 'code'" >&2
+  echo "       execute-code.sh [--port PORT] script.py" >&2
+  exit 1
+fi
+
+# Locate the servers directory
+if [[ "$OSTYPE" == msys* || "$OSTYPE" == cygwin* ]]; then
+  servers_dir="$HOME/.marimo/servers"
+else
+  servers_dir="${XDG_STATE_HOME:-$HOME/.local/state}/marimo/servers"
+fi
+
+# Find a live registry entry
+entry=""
+count=0
+for f in "$servers_dir"/*.json; do
+  [[ -e "$f" ]] || continue
+
+  pid=$(jq -r '.pid' "$f" 2>/dev/null) || continue
+  if ! kill -0 "$pid" 2>/dev/null; then
+    rm -f "$f"
+    continue
+  fi
+
+  e=$(cat "$f")
+
+  if [[ -n "$port" ]]; then
+    e_port=$(echo "$e" | jq -r '.port')
+    if [[ "$e_port" == "$port" ]]; then
+      entry="$e"
+      count=1
+      break
+    fi
+    continue
+  fi
+
+  entry="$e"
+  count=$((count + 1))
+done
+
+if [[ $count -eq 0 ]]; then
+  echo "No running marimo instances found." >&2
+  exit 1
+fi
+
+if [[ $count -gt 1 ]]; then
+  echo "Multiple instances found. Use --port to specify:" >&2
+  for f in "$servers_dir"/*.json; do
+    [[ -e "$f" ]] || continue
+    pid=$(jq -r '.pid' "$f" 2>/dev/null) || continue
+    kill -0 "$pid" 2>/dev/null || continue
+    jq -r '.server_id' "$f" >&2
+  done
+  exit 1
+fi
+
+host=$(echo "$entry" | jq -r '.host')
+e_port=$(echo "$entry" | jq -r '.port')
+base_url=$(echo "$entry" | jq -r '.base_url')
+base="http://${host}:${e_port}${base_url}"
+
+# Discover session ID
+sessions_resp=$(curl -sf "${base}/api/sessions") || {
+  echo "Failed to connect to marimo server at ${base}" >&2
+  exit 1
+}
+
+session_ids=$(echo "$sessions_resp" | jq -r 'keys[]')
+
+if [[ -z "$session_ids" ]]; then
+  echo "No active sessions on the server. Make sure a notebook is open in the browser." >&2
+  exit 1
+fi
+
+session_count=$(echo "$session_ids" | wc -l | tr -d ' ')
+
+if [[ $session_count -gt 1 ]]; then
+  echo "Multiple sessions on server. Cannot auto-select:" >&2
+  echo "$sessions_resp" | jq -r 'to_entries[] | "\(.key)  \(.value.filename // "")"' >&2
+  exit 1
+fi
+
+session_id=$(echo "$session_ids" | head -1)
+
+# Execute code via SSE stream
+# Events: stdout/stderr stream as JSON {"data":"..."}, done is final result.
+exit_code=0
+current_event=""
+done_received=false
+while IFS= read -r line && [[ "$done_received" == false ]]; do
+  case "$line" in
+    event:*)
+      current_event="${line#event: }"
+      ;;
+    data:*)
+      payload="${line#data: }"
+      case "$current_event" in
+        stdout)
+          echo "$payload" | jq -jr '.data'
+          ;;
+        stderr)
+          echo "$payload" | jq -jr '.data' >&2
+          ;;
+        done)
+          if echo "$payload" | jq -e '.success == false' >/dev/null 2>&1; then
+            echo "$payload" | jq -r '.error.msg' >&2
+            exit_code=1
+          else
+            echo "$payload" | jq -r '.output.data // empty'
+          fi
+          done_received=true
+          ;;
+      esac
+      ;;
+  esac
+done < <(curl -sN -X POST "${base}/api/kernel/execute" \
+  -H "Content-Type: application/json" \
+  -H "Marimo-Session-Id: ${session_id}" \
+  -d "$(jq -n --arg c "$code" '{code: $c}')" \
+)
+
+exit "$exit_code"

--- a/.claude/skills/marimo-pair
+++ b/.claude/skills/marimo-pair
@@ -1,0 +1,1 @@
+../../.agents/skills/marimo-pair

--- a/randopt-ensemble/randopt-ensemble.py
+++ b/randopt-ensemble/randopt-ensemble.py
@@ -1,0 +1,446 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "marimo",
+#     "torch>=2.0.0",
+#     "transformers",
+#     "pydantic",
+#     "wandb",
+#     "python-dotenv",
+#     "wigglystuff",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.21.0"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import os
+    import marimo as mo
+    import torch
+    import random
+    import wandb
+    from pathlib import Path
+    from collections import Counter
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+    from pydantic import BaseModel, Field
+    from dotenv import load_dotenv
+
+    load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+    return (
+        AutoModelForCausalLM,
+        AutoTokenizer,
+        BaseModel,
+        Counter,
+        Field,
+        mo,
+        random,
+        torch,
+        wandb,
+    )
+
+
+@app.cell(hide_code=True)
+def _(wandb):
+    from wigglystuff import EnvConfig
+
+    env_config = EnvConfig({
+        "WANDB_API_KEY": lambda k: wandb.login(key=k, verify=True),
+    })
+
+    env_config
+    return (env_config,)
+
+
+@app.cell
+def _(BaseModel, Field, env_config, mo):
+    if mo.app_meta().mode != "script":
+        env_config.require_valid()
+
+    class ModelParams(BaseModel):
+        model_id: str = Field(
+            default="Qwen/Qwen2.5-0.5B-Instruct",
+            description="HuggingFace model ID to use as base model.",
+        )
+        sigma: float = Field(
+            default=1e-3,
+            description="Noise scale for parameter perturbation.",
+        )
+        n_population: int = Field(
+            default=10,
+            description="Number of random seeds to search over.",
+        )
+        k_ensemble: int = Field(
+            default=3,
+            description="Number of top seeds to use in the ensemble.",
+        )
+        n_train_samples: int = Field(
+            default=10,
+            description="Number of training samples.",
+        )
+        n_test_samples: int = Field(
+            default=10,
+            description="Number of test samples.",
+        )
+        max_number: int = Field(
+            default=100,
+            description="Upper bound for random numbers in the pool.",
+        )
+        group_size: int = Field(
+            default=4,
+            description="How many numbers to pick for the target sum.",
+        )
+        wandb_project: str = Field(
+            default="randopt-ensemble",
+            description="Weights & Biases project name.",
+        )
+        wandb_run_name: str | None = Field(
+            default=None,
+            description="Optional Weights & Biases run name override.",
+        )
+
+    return (ModelParams,)
+
+
+@app.cell
+def _(mo):
+    el = mo.md("""
+    {model_id}
+
+    {sigma}
+
+    {n_population}
+
+    {k_ensemble}
+
+    {n_train_samples}
+
+    {n_test_samples}
+
+    {max_number}
+
+    {group_size}
+
+    {wandb_project}
+    """).batch(
+        model_id=mo.ui.dropdown(options=[
+            "Qwen/Qwen2.5-3B-Instruct",
+            "Qwen/Qwen2.5-7B-Instruct",
+            "google/gemma-2-2b-it",
+            "google/gemma-3-4b-it",
+            "microsoft/Phi-4-mini-instruct",
+        ], value="Qwen/Qwen2.5-3B-Instruct", label="Model ID"),
+        sigma=mo.ui.slider(1e-4, 1e-1, value=1e-3, step=1e-4, label="Sigma (noise scale)"),
+        n_population=mo.ui.slider(2, 50, value=10, step=1, label="Population size"),
+        k_ensemble=mo.ui.slider(1, 10, value=3, step=1, label="Ensemble size (K)"),
+        n_train_samples=mo.ui.slider(5, 100, value=15, step=5, label="Train samples"),
+        n_test_samples=mo.ui.slider(5, 100, value=25, step=5, label="Test samples"),
+        max_number=mo.ui.slider(10, 200, value=10, step=10, label="Max number"),
+        group_size=mo.ui.slider(2, 8, value=3, step=1, label="Group size"),
+        wandb_project=mo.ui.text(value="randopt-ensemble", label="W&B Project"),
+    ).form()
+    el
+    return (el,)
+
+
+@app.cell
+def _(ModelParams, el, mo):
+    if mo.app_meta().mode == "script":
+        cli_args = mo.cli_args()
+        if "help" in cli_args or len(cli_args) == 0:
+            print("Usage: uv run randopt-ensemble.py --model-id <id> [options]")
+            print()
+            for name, field in ModelParams.model_fields.items():
+                if field.is_required():
+                    default = " (required)"
+                elif field.default is None:
+                    default = " (optional)"
+                else:
+                    default = f" (default: {field.default})"
+                print(f"  --{name.replace('_', '-'):20s} {field.description}{default}")
+            exit()
+        model_params = ModelParams(
+            **{k.replace("-", "_"): v for k, v in cli_args.items()}
+        )
+    else:
+        mo.stop(el.value is None, mo.md("Submit the form to continue."))
+        model_params = ModelParams(**el.value)
+
+    if not model_params.wandb_run_name:
+        model_short_name = model_params.model_id.split("/")[-1].lower()
+        for suffix in ("-instruct", "-it"):
+            if model_short_name.endswith(suffix):
+                model_short_name = model_short_name.removesuffix(suffix)
+        generated_run_name = (
+            f"{model_short_name}"
+            f"-s{model_params.sigma}"
+            f"-p{model_params.n_population}"
+            f"-k{model_params.k_ensemble}"
+        )
+        model_params = model_params.model_copy(
+            update={"wandb_run_name": generated_run_name}
+        )
+
+    mo.md(f"""
+    ### Active Parameters
+
+    | Parameter | Value |
+    |-----------|-------|
+    | Model | `{model_params.model_id}` |
+    | Sigma | `{model_params.sigma}` |
+    | Population | `{model_params.n_population}` |
+    | Ensemble K | `{model_params.k_ensemble}` |
+    | Train samples | `{model_params.n_train_samples}` |
+    | Test samples | `{model_params.n_test_samples}` |
+    | Max number | `{model_params.max_number}` |
+    | Group size | `{model_params.group_size}` |
+    | W&B Project | `{model_params.wandb_project}` |
+    | W&B Run | `{model_params.wandb_run_name}` |
+    """)
+    return (model_params,)
+
+
+@app.cell
+def _(AutoModelForCausalLM, AutoTokenizer, model_params, torch):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    torch_dtype = torch.float16 if device == "cuda" else torch.float32
+    tokenizer = AutoTokenizer.from_pretrained(model_params.model_id)
+    base_model = AutoModelForCausalLM.from_pretrained(
+        model_params.model_id,
+        torch_dtype=torch_dtype,
+        low_cpu_mem_usage=True,
+    ).to(device)
+    base_model.eval()
+    return base_model, device, tokenizer
+
+
+@app.cell
+def _(random):
+    def generate_4num_data(n_samples=10, max_number=100, group_size=4):
+        data = []
+        pool_size = 2 * group_size
+        for _ in range(n_samples):
+            pool = random.sample(range(1, max_number), pool_size)
+            subset = random.sample(pool, group_size)
+            target = sum(subset)
+            answer_str = ", ".join(map(str, sorted(subset)))
+            data.append({
+                "nums": pool,
+                "target": target,
+                "answer": answer_str,
+            })
+        return data
+
+    return (generate_4num_data,)
+
+
+@app.cell
+def _(device, model_params, tokenizer, torch):
+    def get_prediction(model, sample):
+        prompt = (
+            f"Numbers: {sample['nums']}. Find EXACTLY {model_params.group_size} that sum to {sample['target']}. "
+            f"Answer only with the {model_params.group_size} numbers separated by commas."
+        )
+        inputs = tokenizer(prompt, return_tensors="pt").to(device)
+        with torch.no_grad():
+            outputs = model.generate(
+                **inputs, max_new_tokens=20, pad_token_id=tokenizer.eos_token_id
+            )
+        response = tokenizer.decode(outputs[0], skip_special_tokens=True).split("commas.")[-1].strip()
+        try:
+            pred_nums = sorted([int(x.strip()) for x in response.replace(",", " ").split()])
+            return ", ".join(map(str, pred_nums))
+        except Exception:
+            return "invalid_format"
+
+    def evaluate_acc(model, dataset):
+        correct = 0
+        for s in dataset:
+            if get_prediction(model, s) == s["answer"]:
+                correct += 1
+        return correct / len(dataset)
+
+    def perturb_model(base_model, seed, sigma, direction=1.0):
+        cuda_devices = [torch.cuda.current_device()] if device == "cuda" else []
+        with torch.random.fork_rng(devices=cuda_devices):
+            torch.manual_seed(seed)
+            if device == "cuda":
+                torch.cuda.manual_seed_all(seed)
+
+            scale = sigma * direction
+            with torch.no_grad():
+                for p in base_model.parameters():
+                    p.add_(torch.randn_like(p) * scale)
+
+    def evaluate_seed(base_model, dataset, seed, sigma):
+        perturb_model(base_model, seed, sigma, direction=1.0)
+        try:
+            return evaluate_acc(base_model, dataset)
+        finally:
+            perturb_model(base_model, seed, sigma, direction=-1.0)
+            if device == "cuda":
+                torch.cuda.empty_cache()
+
+    def predict_with_seed(base_model, dataset, seed, sigma):
+        perturb_model(base_model, seed, sigma, direction=1.0)
+        try:
+            return [get_prediction(base_model, sample) for sample in dataset]
+        finally:
+            perturb_model(base_model, seed, sigma, direction=-1.0)
+            if device == "cuda":
+                torch.cuda.empty_cache()
+
+    return evaluate_acc, evaluate_seed, predict_with_seed
+
+
+@app.cell
+def _(generate_4num_data, model_params):
+    train_data = generate_4num_data(model_params.n_train_samples, model_params.max_number, model_params.group_size)
+    test_data = generate_4num_data(model_params.n_test_samples, model_params.max_number, model_params.group_size)
+    return test_data, train_data
+
+
+@app.cell
+def _(train_data):
+    train_data
+    return
+
+
+@app.cell
+def _(base_model, evaluate_seed, mo, model_params, train_data, wandb):
+    wandb_config = model_params.model_dump()
+    run = wandb.init(
+        project=model_params.wandb_project,
+        name=model_params.wandb_run_name,
+        config=wandb_config,
+    )
+    wandb.config.update(wandb_config, allow_val_change=True)
+    for _config_key, _config_value in wandb_config.items():
+        wandb.summary[_config_key] = _config_value
+
+    seed_results = []
+    for _search_index, _seed in enumerate(range(model_params.n_population), start=1):
+        print(
+            f"[search {_search_index}/{model_params.n_population}] evaluating seed={_seed}",
+            flush=True,
+        )
+        acc = evaluate_seed(base_model, train_data, _seed, model_params.sigma)
+        seed_results.append({"seed": _seed, "train_acc": acc})
+        wandb.log({"seed": _seed, "train_acc": acc})
+        print(
+            f"[search {_search_index}/{model_params.n_population}] seed={_seed} train_acc={acc:.1%}",
+            flush=True,
+        )
+
+    seed_results_sorted = sorted(seed_results, key=lambda x: x["train_acc"], reverse=True)
+    top_seeds = [r["seed"] for r in seed_results_sorted[: model_params.k_ensemble]]
+
+    mo.md(f"""
+    ### Parallel Search Complete
+
+    Top seeds: `{top_seeds}`
+
+    | Seed | Train Accuracy |
+    |------|---------------|
+    {"".join(f"| {r['seed']} | {r['train_acc']:.1%} |" + chr(10) for r in seed_results_sorted)}
+    """)
+    return (top_seeds,)
+
+
+@app.cell
+def _(
+    Counter,
+    base_model,
+    evaluate_acc,
+    mo,
+    model_params,
+    predict_with_seed,
+    test_data,
+    top_seeds,
+    wandb,
+):
+    print("[base] evaluating base model on test set", flush=True)
+    base_acc = evaluate_acc(base_model, test_data)
+    print(f"[base] base_test_acc={base_acc:.1%}", flush=True)
+
+    seed_predictions = {}
+    for _ensemble_index, _seed in enumerate(top_seeds, start=1):
+        print(
+            f"[ensemble {_ensemble_index}/{len(top_seeds)}] generating predictions for seed={_seed}",
+            flush=True,
+        )
+        seed_predictions[_seed] = predict_with_seed(
+            base_model, test_data, _seed, model_params.sigma
+        )
+
+    votes_correct = 0
+    test_predictions = []
+    progress_interval = max(1, len(test_data) // 5)
+
+    for idx, sample in enumerate(test_data):
+        all_preds = [seed_predictions[_seed][idx] for _seed in top_seeds]
+
+        final_answer = Counter(all_preds).most_common(1)[0][0]
+        is_correct = final_answer == sample["answer"]
+        if is_correct:
+            votes_correct += 1
+
+        test_predictions.append({
+            "nums": str(sample["nums"]),
+            "target": sample["target"],
+            "answer": sample["answer"],
+            "ensemble_prediction": final_answer,
+            "correct": is_correct,
+            "individual_predictions": str(all_preds),
+        })
+
+        if (idx + 1) % progress_interval == 0 or idx + 1 == len(test_data):
+            print(
+                f"[vote {idx + 1}/{len(test_data)}] running_ensemble_acc={votes_correct / (idx + 1):.1%}",
+                flush=True,
+            )
+
+    ensemble_acc = votes_correct / len(test_data)
+    uplift_abs = ensemble_acc - base_acc
+    uplift_rel = (ensemble_acc / base_acc - 1.0) if base_acc else None
+    uplift_rel_display = f"{uplift_rel:+.1%}" if uplift_rel is not None else "n/a"
+
+    wandb.log({
+        "base_test_acc": base_acc,
+        "ensemble_test_acc": ensemble_acc,
+        "uplift_abs": uplift_abs,
+        "uplift_rel": uplift_rel,
+    })
+    wandb.summary["base_test_acc"] = base_acc
+    wandb.summary["ensemble_test_acc"] = ensemble_acc
+    wandb.summary["uplift_abs"] = uplift_abs
+    if uplift_rel is not None:
+        wandb.summary["uplift_rel"] = uplift_rel
+    wandb.summary["top_seeds"] = str(top_seeds)
+
+    mo.md(f"""
+    ### Final Results (4-Number Task)
+
+    | Metric | Value |
+    |--------|-------|
+    | Base Accuracy | {base_acc:.1%} |
+    | Ensemble Accuracy | {ensemble_acc:.1%} |
+    | Absolute Uplift | {uplift_abs:+.1%} |
+    | Relative Uplift | {uplift_rel_display} |
+    """)
+    return
+
+
+@app.cell
+def _(mo, wandb):
+    wandb.finish()
+    mo.md("### Run complete. Data logged to W&B.")
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/randopt-ensemble/run_grid.py
+++ b/randopt-ensemble/run_grid.py
@@ -1,0 +1,133 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "huggingface-hub>=0.30",
+#     "python-dotenv",
+# ]
+# ///
+
+"""
+Grid search launcher for randopt-ensemble.py on Hugging Face Jobs.
+
+Usage:
+    # Dry run (print what would be launched)
+    uv run randopt-ensemble/run_grid.py
+
+    # Actually launch
+    uv run randopt-ensemble/run_grid.py --launch
+"""
+
+import itertools
+import os
+import argparse
+from pathlib import Path
+from dotenv import load_dotenv
+from huggingface_hub import run_uv_job
+
+PROJECT_DIR = Path(__file__).resolve().parent
+ROOT_DIR = PROJECT_DIR.parent
+NOTEBOOK_PATH = PROJECT_DIR / "randopt-ensemble.py"
+
+load_dotenv(ROOT_DIR / ".env")
+
+# --- Grid definition ---
+GRID = {
+    "model_id": [
+        "Qwen/Qwen2.5-3B-Instruct",
+    ],
+    "sigma": [1e-3, 2 * 1e-3, 2 * 1e-4],
+    "n_population": [100],
+    "k_ensemble": [3, 4],
+}
+
+# --- Fixed params ---
+FIXED = {
+    "n_train_samples": "20",
+    "n_test_samples": "20",
+    "max_number": "10",
+    "group_size": "2",
+    "wandb_project": "randopt-ensemble",
+}
+
+SMALL_MODEL_FLAVOR = "t4-small"
+LARGE_MODEL_FLAVOR = "l4x1"
+TIMEOUT = "1h"
+
+
+def pick_flavor(model_id):
+    model_name = model_id.lower()
+    if any(tag in model_name for tag in ("7b", "8b", "9b")):
+        return LARGE_MODEL_FLAVOR
+    return SMALL_MODEL_FLAVOR
+
+
+def build_runs(grid, fixed):
+    keys = list(grid.keys())
+    combos = list(itertools.product(*grid.values()))
+    runs = []
+    for combo in combos:
+        params = {k: str(v) for k, v in zip(keys, combo)}
+        params.update(fixed)
+        model_short_name = params["model_id"].split("/")[-1].lower()
+        for suffix in ("-instruct", "-it"):
+            if model_short_name.endswith(suffix):
+                model_short_name = model_short_name.removesuffix(suffix)
+        params["wandb_run_name"] = (
+            f"{model_short_name}"
+            f"-s{params['sigma']}"
+            f"-p{params['n_population']}"
+            f"-k{params['k_ensemble']}"
+        )
+        runs.append(params)
+    return runs
+
+
+def params_to_cli_args(params):
+    args = []
+    for k, v in params.items():
+        args.extend([f"--{k.replace('_', '-')}", str(v)])
+    return args
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--launch", action="store_true", help="Actually launch the jobs (default is dry run)")
+    args = parser.parse_args()
+
+    secrets = {
+        "HF_TOKEN": os.environ["HF_TOKEN"],
+        "WANDB_API_KEY": os.environ["WANDB_API_KEY"],
+    }
+
+    runs = build_runs(GRID, FIXED)
+    print(
+        f"Grid has {len(runs)} runs "
+        f"(default flavor={SMALL_MODEL_FLAVOR}, large-model flavor={LARGE_MODEL_FLAVOR}, timeout={TIMEOUT})\n"
+    )
+
+    for i, params in enumerate(runs):
+        flavor = pick_flavor(params["model_id"])
+        cli_args = params_to_cli_args(params)
+        print(f"[{i+1}/{len(runs)}] {params['wandb_run_name']}")
+        print(f"  flavor: {flavor}")
+        print(f"  args: {' '.join(cli_args)}")
+
+        if args.launch:
+            job = run_uv_job(
+                str(NOTEBOOK_PATH),
+                script_args=cli_args,
+                flavor=flavor,
+                secrets=secrets,
+                timeout=TIMEOUT,
+            )
+            print(f"  launched: {job.url}")
+        else:
+            print("  (dry run)")
+        print()
+
+    if not args.launch:
+        print("Dry run complete. Pass --launch to submit jobs.")
+
+
+if __name__ == "__main__":
+    main()

--- a/randopt-surface/randopt-surface.py
+++ b/randopt-surface/randopt-surface.py
@@ -1,0 +1,435 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "marimo",
+#     "numpy",
+#     "torch>=2.0.0",
+#     "transformers",
+#     "pydantic",
+#     "wandb",
+#     "python-dotenv",
+#     "wigglystuff",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.21.0"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    import numpy as np
+    import random
+    import torch
+    import wandb
+    from pathlib import Path
+    from dotenv import load_dotenv
+    from pydantic import BaseModel, Field
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+    return AutoModelForCausalLM, AutoTokenizer, BaseModel, Field, mo, np, random, torch, wandb
+
+
+@app.cell(hide_code=True)
+def _(wandb):
+    from wigglystuff import EnvConfig
+
+    env_config = EnvConfig({
+        "WANDB_API_KEY": lambda k: wandb.login(key=k, verify=True),
+    })
+
+    env_config
+    return (env_config,)
+
+
+@app.cell
+def _(BaseModel, Field, env_config, mo):
+    if mo.app_meta().mode != "script":
+        env_config.require_valid()
+
+    class ModelParams(BaseModel):
+        model_id: str = Field(
+            default="Qwen/Qwen2.5-3B-Instruct",
+            description="HuggingFace model ID to use as base model.",
+        )
+        sigma: float = Field(
+            default=2e-3,
+            description="Noise scale for parameter perturbation.",
+        )
+        min_seed: int = Field(
+            default=0,
+            description="Inclusive lower bound for evaluated seeds.",
+        )
+        max_seed: int = Field(
+            default=10,
+            description="Exclusive upper bound for evaluated seeds.",
+        )
+        n_train_samples: int = Field(
+            default=100,
+            description="Number of samples in the fixed evaluation set.",
+        )
+        max_number: int = Field(
+            default=10,
+            description="Upper bound for random numbers in the pool.",
+        )
+        group_size: int = Field(
+            default=2,
+            description="How many numbers to pick for the target sum.",
+        )
+        data_seed: int = Field(
+            default=0,
+            description="Seed used to generate the train/test datasets.",
+        )
+        wandb_project: str = Field(
+            default="randopt-surface",
+            description="Weights & Biases project name.",
+        )
+        wandb_group: str | None = Field(
+            default=None,
+            description="Optional W&B group used to group per-seed runs.",
+        )
+        wandb_run_name: str | None = Field(
+            default=None,
+            description="Optional prefix used for per-seed W&B run names.",
+        )
+
+    return (ModelParams,)
+
+
+@app.cell
+def _(mo):
+    el = mo.md("""
+    {model_id}
+
+    {sigma}
+
+    {min_seed}
+
+    {max_seed}
+
+    {n_train_samples}
+
+    {max_number}
+
+    {group_size}
+
+    {data_seed}
+
+    {wandb_project}
+
+    {wandb_group}
+
+    {wandb_run_name}
+    """).batch(
+        model_id=mo.ui.dropdown(
+            options=[
+                "Qwen/Qwen2.5-3B-Instruct",
+                "Qwen/Qwen2.5-7B-Instruct",
+                "google/gemma-2-2b-it",
+                "google/gemma-3-4b-it",
+                "microsoft/Phi-4-mini-instruct",
+            ],
+            value="Qwen/Qwen2.5-3B-Instruct",
+            label="Model ID",
+        ),
+        sigma=mo.ui.number(value=2e-3, start=1e-4, stop=1e-1, step=1e-4, label="Sigma"),
+        min_seed=mo.ui.number(value=0, start=0, stop=10_000, step=1, label="Min seed"),
+        max_seed=mo.ui.number(value=10, start=1, stop=10_000, step=1, label="Max seed (exclusive)"),
+        n_train_samples=mo.ui.slider(10, 500, value=100, step=10, label="Samples"),
+        max_number=mo.ui.slider(10, 200, value=10, step=10, label="Max number"),
+        group_size=mo.ui.slider(2, 8, value=2, step=1, label="Group size"),
+        data_seed=mo.ui.number(value=0, start=0, stop=10_000, step=1, label="Data seed"),
+        wandb_project=mo.ui.text(value="randopt-surface", label="W&B Project"),
+        wandb_group=mo.ui.text(value="", label="W&B Group"),
+        wandb_run_name=mo.ui.text(value="", label="W&B Run Prefix"),
+    ).form()
+    el
+    return (el,)
+
+
+@app.cell
+def _(ModelParams, el, mo):
+    if mo.app_meta().mode == "script":
+        cli_args = mo.cli_args()
+        if "help" in cli_args or len(cli_args) == 0:
+            print("Usage: uv run randopt-surface.py --model-id <id> [options]")
+            print()
+            for name, field in ModelParams.model_fields.items():
+                if field.is_required():
+                    default = " (required)"
+                elif field.default is None:
+                    default = " (optional)"
+                else:
+                    default = f" (default: {field.default})"
+                print(f"  --{name.replace('_', '-'):20s} {field.description}{default}")
+            raise SystemExit(0)
+        model_params = ModelParams(
+            **{k.replace("-", "_"): v for k, v in cli_args.items()}
+        )
+    else:
+        mo.stop(el.value is None, mo.md("Submit the form to continue."))
+        raw_values = {
+            k: (v if v != "" else None)
+            for k, v in el.value.items()
+        }
+        model_params = ModelParams(**raw_values)
+
+    if model_params.max_seed <= model_params.min_seed:
+        raise ValueError("max_seed must be greater than min_seed.")
+
+    model_short_name = model_params.model_id.split("/")[-1].lower()
+    for suffix in ("-instruct", "-it"):
+        if model_short_name.endswith(suffix):
+            model_short_name = model_short_name.removesuffix(suffix)
+
+    updates = {}
+    if not model_params.wandb_group:
+        updates["wandb_group"] = (
+            f"{model_short_name}-s{model_params.sigma}-data{model_params.data_seed}"
+        )
+    if not model_params.wandb_run_name:
+        updates["wandb_run_name"] = (
+            f"{model_short_name}-s{model_params.sigma}"
+            f"-seeds{model_params.min_seed}-{model_params.max_seed}"
+            f"-data{model_params.data_seed}"
+        )
+    if updates:
+        model_params = model_params.model_copy(update=updates)
+
+    n_seeds = model_params.max_seed - model_params.min_seed
+    mo.md(f"""
+    ### Active Parameters
+
+    | Parameter | Value |
+    |-----------|-------|
+    | Model | `{model_params.model_id}` |
+    | Sigma | `{model_params.sigma}` |
+    | Min seed | `{model_params.min_seed}` |
+    | Max seed | `{model_params.max_seed}` |
+    | Seed count | `{n_seeds}` |
+    | Samples | `{model_params.n_train_samples}` |
+    | Max number | `{model_params.max_number}` |
+    | Group size | `{model_params.group_size}` |
+    | Data seed | `{model_params.data_seed}` |
+    | W&B Project | `{model_params.wandb_project}` |
+    | W&B Group | `{model_params.wandb_group}` |
+    | W&B Run Prefix | `{model_params.wandb_run_name}` |
+    | RNG backend | `numpy_pcg64_cpu` |
+    """)
+    return model_params, n_seeds
+
+
+@app.cell
+def _(AutoModelForCausalLM, AutoTokenizer, model_params, torch):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    torch_dtype = torch.float16 if device == "cuda" else torch.float32
+    tokenizer = AutoTokenizer.from_pretrained(model_params.model_id)
+    base_model = AutoModelForCausalLM.from_pretrained(
+        model_params.model_id,
+        torch_dtype=torch_dtype,
+        low_cpu_mem_usage=True,
+    ).to(device)
+    base_model.eval()
+    return base_model, device, tokenizer
+
+
+@app.cell
+def _(random):
+    def generate_subset_sum_data(n_samples=10, max_number=100, group_size=4, seed=0):
+        data = []
+        rng = random.Random(seed)
+        pool_size = 2 * group_size
+        for _ in range(n_samples):
+            pool = rng.sample(range(1, max_number), pool_size)
+            subset = rng.sample(pool, group_size)
+            target = sum(subset)
+            answer_str = ", ".join(map(str, sorted(subset)))
+            data.append({
+                "nums": pool,
+                "target": target,
+                "answer": answer_str,
+            })
+        return data
+
+    return (generate_subset_sum_data,)
+
+
+@app.cell
+def _(device, model_params, tokenizer, torch):
+    def get_prediction(model, sample):
+        prompt = (
+            f"Numbers: {sample['nums']}. Find EXACTLY {model_params.group_size} that sum to {sample['target']}. "
+            f"Answer only with the {model_params.group_size} numbers separated by commas."
+        )
+        inputs = tokenizer(prompt, return_tensors="pt").to(device)
+        with torch.no_grad():
+            outputs = model.generate(
+                **inputs,
+                max_new_tokens=20,
+                pad_token_id=tokenizer.eos_token_id,
+            )
+        response = tokenizer.decode(outputs[0], skip_special_tokens=True).split("commas.")[-1].strip()
+        try:
+            pred_nums = sorted([int(x.strip()) for x in response.replace(",", " ").split()])
+            return ", ".join(map(str, pred_nums))
+        except ValueError:
+            return "invalid_format"
+
+    def evaluate_acc(model, dataset):
+        correct = 0
+        for sample in dataset:
+            if get_prediction(model, sample) == sample["answer"]:
+                correct += 1
+        return correct / len(dataset)
+
+    return evaluate_acc, get_prediction
+
+
+@app.cell
+def _(device, np, torch):
+    def perturb_model(base_model, seed, sigma, direction=1.0):
+        rng = np.random.Generator(np.random.PCG64(seed))
+        scale = sigma * direction
+        with torch.no_grad():
+            for param in base_model.parameters():
+                noise = rng.standard_normal(param.shape, dtype=np.float32)
+                noise_tensor = torch.from_numpy(noise).to(device=param.device, dtype=param.dtype)
+                param.add_(noise_tensor, alpha=scale)
+
+        if device == "cuda":
+            torch.cuda.synchronize()
+
+    return (perturb_model,)
+
+
+@app.cell
+def _(device, evaluate_acc, perturb_model, torch):
+    def evaluate_seed(base_model, dataset, seed, sigma):
+        perturb_model(base_model, seed, sigma, direction=1.0)
+        try:
+            return evaluate_acc(base_model, dataset)
+        finally:
+            perturb_model(base_model, seed, sigma, direction=-1.0)
+            if device == "cuda":
+                torch.cuda.empty_cache()
+
+    return (evaluate_seed,)
+
+
+@app.cell
+def _(generate_subset_sum_data, model_params):
+    eval_data = generate_subset_sum_data(
+        model_params.n_train_samples,
+        model_params.max_number,
+        model_params.group_size,
+        model_params.data_seed,
+    )
+    return (eval_data,)
+
+
+@app.cell
+def _(base_model, eval_data, evaluate_acc):
+    base_acc = evaluate_acc(base_model, eval_data)
+    return (base_acc,)
+
+
+@app.cell
+def _(
+    base_model,
+    base_acc,
+    eval_data,
+    evaluate_seed,
+    model_params,
+    n_seeds,
+    wandb,
+):
+    results = []
+    common_config = model_params.model_dump()
+    common_config["perturbation_rng"] = "numpy_pcg64_cpu"
+    common_config["seed_count"] = n_seeds
+
+    for index, seed in enumerate(range(model_params.min_seed, model_params.max_seed), start=1):
+        print(f"[seed {index}/{n_seeds}] evaluating seed={seed}", flush=True)
+        seed_acc = evaluate_seed(base_model, eval_data, seed, model_params.sigma)
+        uplift_abs = seed_acc - base_acc
+        uplift_rel = (seed_acc / base_acc - 1.0) if base_acc else None
+        run_name = f"{model_params.wandb_run_name}-seed{seed}"
+
+        run_config = dict(common_config)
+        run_config["seed"] = seed
+
+        with wandb.init(
+            project=model_params.wandb_project,
+            group=model_params.wandb_group,
+            name=run_name,
+            config=run_config,
+        ) as run:
+            metrics = {
+                "base_acc": base_acc,
+                "seed_acc": seed_acc,
+                "uplift_abs": uplift_abs,
+                "seed": seed,
+            }
+            if uplift_rel is not None:
+                metrics["uplift_rel"] = uplift_rel
+
+            run.log(metrics)
+            for key, value in run_config.items():
+                run.summary[key] = value
+            run.summary["base_acc"] = base_acc
+            run.summary["seed_acc"] = seed_acc
+            run.summary["uplift_abs"] = uplift_abs
+            if uplift_rel is not None:
+                run.summary["uplift_rel"] = uplift_rel
+
+        results.append({
+            "seed": seed,
+            "seed_acc": seed_acc,
+            "uplift_abs": uplift_abs,
+            "uplift_rel": uplift_rel,
+        })
+        print(
+            f"[seed {index}/{n_seeds}] seed={seed} "
+            f"acc={seed_acc:.1%} uplift={uplift_abs:+.1%}",
+            flush=True,
+        )
+
+    return common_config, results
+
+
+@app.cell
+def _(base_acc, mo, results):
+    results_sorted = sorted(results, key=lambda row: row["seed_acc"], reverse=True)
+    preview_rows = results_sorted[:10]
+    row_lines = []
+    for row in preview_rows:
+        uplift_rel_display = f"{row['uplift_rel']:+.1%}" if row["uplift_rel"] is not None else "n/a"
+        row_lines.append(
+            f"| {row['seed']} | {row['seed_acc']:.1%} | "
+            f"{row['uplift_abs']:+.1%} | {uplift_rel_display} |"
+        )
+    table_rows = "\n".join(row_lines)
+
+    mo.md(f"""
+    ### Seed Sweep Complete
+
+    | Metric | Value |
+    |--------|-------|
+    | Base accuracy | {base_acc:.1%} |
+    | Evaluated seeds | {len(results)} |
+
+    Top seeds by accuracy:
+
+    | Seed | Accuracy | Absolute Uplift | Relative Uplift |
+    |------|----------|-----------------|-----------------|
+    {table_rows}
+    """)
+    return (results_sorted,)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/randopt-surface/run_grid.py
+++ b/randopt-surface/run_grid.py
@@ -1,0 +1,124 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "huggingface-hub>=0.30",
+#     "python-dotenv",
+# ]
+# ///
+
+"""
+Seed-range launcher for randopt-surface.py on Hugging Face Jobs.
+
+Usage:
+    uv run randopt-surface/run_grid.py
+    uv run randopt-surface/run_grid.py --launch
+"""
+
+import argparse
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+from huggingface_hub import run_uv_job
+
+PROJECT_DIR = Path(__file__).resolve().parent
+ROOT_DIR = PROJECT_DIR.parent
+NOTEBOOK_PATH = PROJECT_DIR / "randopt-surface.py"
+
+load_dotenv(ROOT_DIR / ".env")
+
+MODEL_ID = "Qwen/Qwen2.5-3B-Instruct"
+SIGMA = 2e-3
+FLAVOR = "l4x1"
+
+FIXED = {
+    "n_train_samples": "100",
+    "max_number": "10",
+    "group_size": "2",
+    "data_seed": "0",
+    "wandb_project": "randopt-surface",
+}
+
+SEEDS_PER_JOB = 25
+N_JOBS = 10
+SEED_RANGES = [
+    (job_index * SEEDS_PER_JOB, (job_index + 1) * SEEDS_PER_JOB)
+    for job_index in range(N_JOBS)
+][1:]
+
+TIMEOUT = "2h"
+
+
+def build_runs(fixed):
+    runs = []
+    model_short_name = MODEL_ID.split("/")[-1].lower()
+    for suffix in ("-instruct", "-it"):
+        if model_short_name.endswith(suffix):
+            model_short_name = model_short_name.removesuffix(suffix)
+
+    wandb_group = f"{model_short_name}-s{SIGMA}-data{fixed['data_seed']}"
+    for min_seed, max_seed in SEED_RANGES:
+        params = {
+            "model_id": MODEL_ID,
+            "sigma": str(SIGMA),
+            "min_seed": str(min_seed),
+            "max_seed": str(max_seed),
+            "wandb_group": wandb_group,
+        }
+        params.update(fixed)
+        params["wandb_run_name"] = (
+            f"{model_short_name}-s{SIGMA}-seeds{min_seed}-{max_seed}"
+            f"-data{fixed['data_seed']}"
+        )
+        runs.append(params)
+    return runs
+
+
+def params_to_cli_args(params):
+    args = []
+    for key, value in params.items():
+        args.extend([f"--{key.replace('_', '-')}", str(value)])
+    return args
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--launch", action="store_true", help="Actually launch the jobs (default is dry run)")
+    args = parser.parse_args()
+
+    secrets = {
+        "HF_TOKEN": os.environ["HF_TOKEN"],
+        "WANDB_API_KEY": os.environ["WANDB_API_KEY"],
+    }
+
+    runs = build_runs(FIXED)
+    print(
+        f"Grid has {len(runs)} runs "
+        f"(seed ranges={SEED_RANGES}, flavor={FLAVOR}, timeout={TIMEOUT})\n"
+    )
+
+    for index, params in enumerate(runs, start=1):
+        cli_args = params_to_cli_args(params)
+        print(f"[{index}/{len(runs)}] {params['wandb_run_name']}")
+        print(f"  flavor: {FLAVOR}")
+        print(f"  args: {' '.join(cli_args)}")
+
+        if args.launch:
+            job = run_uv_job(
+                str(NOTEBOOK_PATH),
+                script_args=cli_args,
+                flavor=FLAVOR,
+                secrets=secrets,
+                timeout=TIMEOUT,
+            )
+            print(f"  launched: {job.url}")
+        else:
+            print("  (dry run)")
+        print()
+
+    if not args.launch:
+        print("Dry run complete. Pass --launch to submit jobs.")
+
+
+if __name__ == "__main__":
+    main()

--- a/randopt-surface/surface-analysis.py
+++ b/randopt-surface/surface-analysis.py
@@ -1,0 +1,342 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "accelerate==1.13.0",
+#     "diskcache==5.6.3",
+#     "marimo",
+#     "matplotlib",
+#     "numpy==2.4.3",
+#     "pandas",
+#     "python-dotenv",
+#     "transformers==5.3.0",
+#     "wandb",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.21.1"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import itertools
+    import marimo as mo
+    import matplotlib.pyplot as plt
+    import numpy as np
+    import pandas as pd
+    import wandb
+    from diskcache import Cache
+    from pathlib import Path
+    from dotenv import load_dotenv
+
+    load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+    return Cache, Path, itertools, mo, np, pd, plt, wandb
+
+
+@app.cell
+def _():
+    from accelerate import init_empty_weights
+    from transformers import AutoConfig, AutoModelForCausalLM
+
+    return AutoConfig, AutoModelForCausalLM, init_empty_weights
+
+
+@app.cell
+def _():
+    wandb_project = "randopt-surface"
+    wandb_group = "qwen2.5-3b-s0.002-data0"
+    max_runs = 500
+    plot_seed_limit = 50
+    camera_seed = 999
+    chunk_size = 1_000_000
+    projection_batch_size = 8
+    return (
+        camera_seed,
+        chunk_size,
+        max_runs,
+        plot_seed_limit,
+        projection_batch_size,
+        wandb_group,
+        wandb_project,
+    )
+
+
+@app.cell
+def _(Path):
+    runs_cache_path = Path(".context") / "randopt-surface-runs.csv"
+    runs_cache_path.parent.mkdir(parents=True, exist_ok=True)
+    return (runs_cache_path,)
+
+
+@app.cell
+def _(
+    itertools,
+    max_runs,
+    np,
+    pd,
+    runs_cache_path,
+    wandb,
+    wandb_group,
+    wandb_project,
+):
+    def _to_float(value):
+        if value is None:
+            return np.nan
+        return float(value)
+
+    api = wandb.Api()
+    entity = api.default_entity
+    path = f"{entity}/{wandb_project}"
+
+    if runs_cache_path.exists():
+        runs_df = pd.read_csv(runs_cache_path)
+    else:
+        filters = {"group": wandb_group}
+        rows = []
+        for run in itertools.islice(api.runs(path=path, filters=filters), max_runs):
+            summary = dict(run.summary)
+            _config = {k: v for k, v in run.config.items() if not k.startswith("_")}
+            _seed = summary.get("seed", _config.get("seed"))
+            if _seed is None:
+                continue
+            rows.append({
+                "run_id": run.id,
+                "name": run.name,
+                "state": run.state,
+                "created_at": run.created_at,
+                "seed": int(_seed),
+                "seed_acc": _to_float(summary.get("seed_acc")),
+                "base_acc": _to_float(summary.get("base_acc")),
+                "uplift_abs": _to_float(summary.get("uplift_abs")),
+                "uplift_rel": _to_float(summary.get("uplift_rel")),
+                "sigma": _to_float(_config.get("sigma")),
+                "model_id": _config.get("model_id"),
+                "data_seed": _config.get("data_seed"),
+                "wandb_group": run.group,
+            })
+
+        runs_df = pd.DataFrame(rows)
+        if not runs_df.empty:
+            runs_df = runs_df.sort_values("seed").reset_index(drop=True)
+        runs_df.to_csv(runs_cache_path, index=False)
+    return path, runs_df
+
+
+@app.cell
+def _(runs_df):
+    model_ids = runs_df["model_id"].dropna().unique().tolist()
+    if len(model_ids) != 1:
+        raise ValueError(f"Expected exactly one model_id, found: {model_ids}")
+    model_id = model_ids[0]
+    return (model_id,)
+
+
+@app.cell
+def _(plot_seed_limit, runs_df):
+    plot_runs_df = runs_df.sort_values("seed").head(plot_seed_limit).reset_index(drop=True)
+    return (plot_runs_df,)
+
+
+@app.cell
+def _(AutoConfig, AutoModelForCausalLM, init_empty_weights, model_id):
+    _config = AutoConfig.from_pretrained(model_id)
+    with init_empty_weights():
+        model = AutoModelForCausalLM.from_config(_config)
+    param_sizes = [param.numel() for param in model.parameters()]
+    total_dim = int(sum(param_sizes))
+    return param_sizes, total_dim
+
+
+@app.cell
+def _(mo, path, plot_runs_df):
+    mo.stop(plot_runs_df.empty, mo.md(f"No runs found for `{path}`."))
+    return
+
+
+@app.cell
+def _(np):
+    def regenerate_noise_prefix(seed, length):
+        rng = np.random.Generator(np.random.PCG64(int(seed)))
+        return rng.standard_normal(length, dtype=np.float32)
+
+    def regenerate_noise_matrix(seeds, length):
+        return np.stack([regenerate_noise_prefix(seed, length) for seed in seeds], axis=0)
+
+    return (regenerate_noise_matrix,)
+
+
+@app.cell
+def _(plot_runs_df, regenerate_noise_matrix):
+    seeds = plot_runs_df["seed"].astype(int).tolist()
+    first_two_coords = regenerate_noise_matrix(seeds, 10)
+    return (first_two_coords,)
+
+
+@app.cell
+def _(Cache, Path):
+    cache_dir = Path(".context") / "randopt-surface-paper-projection-cache"
+    cache_dir.parent.mkdir(parents=True, exist_ok=True)
+    projection_cache = Cache(str(cache_dir))
+    return (projection_cache,)
+
+
+@app.cell
+def _(
+    camera_seed,
+    chunk_size,
+    np,
+    param_sizes,
+    pd,
+    plot_runs_df,
+    projection_batch_size,
+    projection_cache,
+    total_dim,
+):
+    projection_cache_version = 2
+
+    def projection_cache_key(seed):
+        return (
+            projection_cache_version,
+            int(camera_seed),
+            int(total_dim),
+            int(seed),
+        )
+
+    known_seeds = {
+        int(seed)
+        for seed in plot_runs_df["seed"].astype(int).tolist()
+        if projection_cache.get(projection_cache_key(seed)) is not None
+    }
+    missing_seeds = [
+        int(seed)
+        for seed in plot_runs_df["seed"].astype(int).tolist()
+        if int(seed) not in known_seeds
+    ]
+
+    scale = float(np.sqrt(total_dim))
+    seed_batches = [
+        missing_seeds[start : start + projection_batch_size]
+        for start in range(0, len(missing_seeds), projection_batch_size)
+    ]
+
+    for index, seed_batch in enumerate(seed_batches, start=1):
+        print(
+            f"[paper projection batch {index}/{len(seed_batches)}] "
+            f"seeds={seed_batch[0]}..{seed_batch[-1]}",
+            flush=True,
+        )
+        expert_rngs = {
+            seed: np.random.Generator(np.random.PCG64(seed))
+            for seed in seed_batch
+        }
+        batch_x = {seed: 0.0 for seed in seed_batch}
+        batch_y = {seed: 0.0 for seed in seed_batch}
+        camera_x_rng = np.random.Generator(np.random.PCG64(camera_seed))
+        camera_y_rng = np.random.Generator(np.random.PCG64(camera_seed + 1))
+
+        for tensor_size in param_sizes:
+            remaining = tensor_size
+            while remaining > 0:
+                current = min(chunk_size, remaining)
+                u = camera_x_rng.standard_normal(current, dtype=np.float32)
+                v = camera_y_rng.standard_normal(current, dtype=np.float32)
+                eps_batch = np.stack(
+                    [
+                        expert_rngs[seed].standard_normal(current, dtype=np.float32)
+                        for seed in seed_batch
+                    ],
+                    axis=0,
+                )
+                batch_x_values = eps_batch @ u
+                batch_y_values = eps_batch @ v
+                for batch_index, seed in enumerate(seed_batch):
+                    batch_x[seed] += float(batch_x_values[batch_index])
+                    batch_y[seed] += float(batch_y_values[batch_index])
+                remaining -= current
+
+        for seed in seed_batch:
+            projection_cache.set(
+                projection_cache_key(seed),
+                (batch_x[seed] / scale, batch_y[seed] / scale),
+            )
+
+    cached_rows = []
+    for seed in plot_runs_df["seed"].astype(int).tolist():
+        cached_value = projection_cache.get(projection_cache_key(seed))
+        if cached_value is None:
+            cached_rows.append({"seed": seed, "paper_x": np.nan, "paper_y": np.nan})
+        else:
+            paper_x, paper_y = cached_value
+            cached_rows.append({"seed": seed, "paper_x": paper_x, "paper_y": paper_y})
+
+    cached_df = pd.DataFrame(cached_rows)
+    paper_projected_df = plot_runs_df.merge(cached_df, on="seed", how="left")
+    return (paper_projected_df,)
+
+
+@app.cell
+def _(first_two_coords, plot_runs_df):
+    projected_df = plot_runs_df.copy()
+    projected_df["draw_1"] = first_two_coords[:, 0]
+    projected_df["draw_2"] = first_two_coords[:, 4]
+    projected_df["uplift_abs_filled"] = projected_df["uplift_abs"].fillna(0.0)
+    return (projected_df,)
+
+
+@app.cell(hide_code=True)
+def _(plt, projected_df):
+    _fig, _ax = plt.subplots(figsize=(5, 5))
+    _scatter = _ax.scatter(
+        projected_df["draw_1"],
+        projected_df["draw_2"],
+        c=projected_df["uplift_abs_filled"],
+        cmap="viridis",
+        s=50,
+        alpha=0.85,
+    )
+    _top_rows = projected_df.sort_values("uplift_abs", ascending=False).head(5)
+    for _, _row in _top_rows.iterrows():
+        _ax.annotate(str(int(_row["seed"])), (_row["draw_1"], _row["draw_2"]), fontsize=8)
+
+    _ax.set_title("Seed First Two Dimensions")
+    _ax.set_xlabel("draw_1")
+    _ax.set_ylabel("draw_2")
+    _fig.colorbar(_scatter, ax=_ax, label="uplift_abs")
+    _fig.tight_layout()
+    _fig
+    return
+
+
+@app.cell(hide_code=True)
+def _(paper_projected_df, plt):
+    _fig, _ax = plt.subplots(figsize=(5, 5))
+    _scatter = _ax.scatter(
+        paper_projected_df["paper_x"],
+        paper_projected_df["paper_y"],
+        c=paper_projected_df["uplift_abs"].fillna(0.0),
+        cmap="viridis",
+        s=50,
+        alpha=0.85,
+    )
+    _top_rows = paper_projected_df.sort_values("uplift_abs", ascending=False).head(5)
+    for _, _row in _top_rows.iterrows():
+        _ax.annotate(str(int(_row["seed"])), (_row["paper_x"], _row["paper_y"]), fontsize=8)
+
+    _ax.set_title("Streaming Random Projection")
+    _ax.set_xlabel("x")
+    _ax.set_ylabel("y")
+    _fig.colorbar(_scatter, ax=_ax, label="uplift_abs")
+    _fig.tight_layout()
+    _fig
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -20,6 +20,11 @@
       "source": "marimo-team/skills",
       "sourceType": "github",
       "computedHash": "48a44d4a8cf223adabad6b28d12134eb8751f4ef4d867474d2f1737c8bf920a4"
+    },
+    "marimo-pair": {
+      "source": "marimo-team/marimo-pair",
+      "sourceType": "github",
+      "computedHash": "4b98f99e850d369d13bc0451bf6a08f665838ffc9f8fc7f51d62f1b5ebaf5515"
     }
   }
 }


### PR DESCRIPTION
This adds two new marimo notebook workflows:  for evaluating noisy model ensembles and  for sweeping seed ranges plus analyzing run geometry in . It also adds Hugging Face job launchers for both workflows and updates  accordingly. Finally, it vendors the  skill under  with the matching  link so notebook sessions can be discovered and driven programmatically.