### PR TITLE
Add conformal mapping and Droste effect notebooks

### DIFF
--- a/chartpuck-circle.py
+++ b/chartpuck-circle.py
@@ -423,11 +423,15 @@ def _(map_coordinates, np):
         px_x = (src.real - plane_bounds[0]) / (plane_bounds[1] - plane_bounds[0]) * w
         px_y = (src.imag - plane_bounds[0]) / (plane_bounds[1] - plane_bounds[0]) * h
 
+        # Mask for pixels that map to valid input coordinates
+        valid = (px_x >= 0) & (px_x < w) & (px_y >= 0) & (px_y < h) & np.isfinite(px_x) & np.isfinite(px_y)
+
         channels = []
         for i in range(3):
-            ch = map_coordinates(img_arr[..., i], [px_y, px_x], order=1, mode="wrap")
+            ch = map_coordinates(img_arr[..., i], [px_y, px_x], order=1, mode="constant", cval=0)
             channels.append(ch)
-        return np.stack(channels, axis=-1)
+        alpha = (valid * 255).astype(np.uint8)
+        return np.dstack([np.stack(channels, axis=-1), alpha])
 
     return (map_image_through,)
 

--- a/chartpuck-circle.py
+++ b/chartpuck-circle.py
@@ -6,6 +6,8 @@
 #     "matplotlib",
 #     "wigglystuff",
 #     "mohtml==0.1.11",
+#     "pillow",
+#     "scipy",
 # ]
 # ///
 
@@ -15,16 +17,17 @@ __generated_with = "0.21.1"
 app = marimo.App(width="full")
 
 
-@app.cell
-def _():
-    import marimo as mo
+app._unparsable_cell(
+    r"""
+    jimport marimo as mo
     import numpy as np
     import matplotlib
     matplotlib.rcParams["figure.dpi"] = 72
     import matplotlib.pyplot as plt
     from wigglystuff import ChartPuck
-
-    return ChartPuck, mo, np, plt
+    """,
+    name="_"
+)
 
 
 @app.cell
@@ -45,7 +48,7 @@ def _(ChartPuck, mo, np, plt):
         ax.set_xlim(x_bounds)
         ax.set_ylim(y_bounds)
         ax.set_aspect("equal")
-        ax.set_title("Complex Plane")
+        ax.set_title("")
 
     puck = mo.ui.anywidget(
         ChartPuck.from_callback(
@@ -84,10 +87,97 @@ def _(mo, np, plt, puck):
     ax.set_ylim(-np.pi, np.pi)
     ax.set_xlabel("ln(r)")
     ax.set_ylabel("θ")
-    ax.set_title("Log Space")
+    ax.set_title("")
 
-    mo.hstack([puck, mo.vstack([div(style="margin-top: 21px;"), fig])], justify="start")
+    mo.hstack([puck, mo.vstack([div(style="margin-top: 37px;"), fig])], justify="start")
+    return (div,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    But what if we apply a mapping of an entire image using this technique?
+    """)
     return
+
+
+@app.cell
+def _(div, log_img, map_log_to_complex, mo, np, plt, puck):
+    arr = np.array(log_img)
+    mapped = map_log_to_complex(arr)
+
+    puck_x, puck_y = puck.x[0], puck.y[0]
+    puck_r = np.sqrt(puck_x**2 + puck_y**2)
+
+    fig_mapped, ax_mapped = plt.subplots(figsize=(6, 6))
+    ax_mapped.imshow(mapped, extent=(-5, 5, -5, 5), origin="lower")
+    circle = plt.Circle((0, 0), puck_r, fill=False, color="#e63946", linewidth=2)
+    ax_mapped.add_patch(circle)
+    ax_mapped.plot(puck_x, puck_y, "o", color="#e63946", markersize=10, zorder=5)
+    ax_mapped.set_xlim(-5, 5)
+    ax_mapped.set_ylim(-5, 5)
+    ax_mapped.set_aspect("equal")
+
+    fig_log, ax_log = plt.subplots(figsize=(6, 6))
+    ax_log.imshow(arr, extent=(-2, 2, -np.pi, np.pi), origin="lower", aspect="auto")
+    log_puck_r = np.log(max(puck_r, 1e-9))
+    angles = np.linspace(-np.pi, np.pi, 200)
+    ax_log.plot(np.full_like(angles, log_puck_r), angles, color="#e63946", linewidth=2)
+    puck_theta = np.arctan2(puck_y, puck_x)
+    ax_log.plot(log_puck_r, puck_theta, "o", color="#e63946", markersize=10, zorder=5)
+    ax_log.set_xlim(-2, 2)
+    ax_log.set_ylim(-np.pi, np.pi)
+    ax_log.set_xlabel("ln(r)")
+    ax_log.set_ylabel("θ")
+
+    mo.hstack([div(style="padding-left: 19px;"), fig_mapped, div(style="padding-left: 28px;"), mo.vstack([fig_log])], justify="start")
+    return
+
+
+@app.cell
+def _():
+    from PIL import Image, ImageDraw
+    from scipy.ndimage import map_coordinates
+
+    return Image, ImageDraw, map_coordinates
+
+
+@app.cell
+def _(Image, ImageDraw):
+    def make_checkerboard(width=400, height=400, tile_size=50):
+        img = Image.new("RGB", (width, height), "white")
+        draw = ImageDraw.Draw(img)
+        for row in range(0, height, tile_size):
+            for col in range(0, width, tile_size):
+                if (row // tile_size + col // tile_size) % 2 == 0:
+                    draw.rectangle([col, row, col + tile_size, row + tile_size], fill="#1f77b4")
+        return img
+
+    log_img = make_checkerboard()
+    return (log_img,)
+
+
+@app.cell
+def _(map_coordinates, np):
+    def map_log_to_complex(img_arr, output_size=400, plane_bounds=(-5, 5), log_bounds=(-2, 2)):
+        h, w, _ = img_arr.shape
+        lin = np.linspace(plane_bounds[0], plane_bounds[1], output_size)
+        gx, gy = np.meshgrid(lin, lin)
+
+        radius = np.sqrt(gx**2 + gy**2)
+        angle = np.arctan2(gy, gx)
+        log_radius = np.log(np.clip(radius, 1e-9, None))
+
+        px_x = (log_radius - log_bounds[0]) / (log_bounds[1] - log_bounds[0]) * w
+        px_y = (angle - (-np.pi)) / (2 * np.pi) * h
+
+        channels = []
+        for i in range(3):
+            ch = map_coordinates(img_arr[..., i], [px_y % h, px_x % w], order=1)
+            channels.append(ch)
+        return np.stack(channels, axis=-1)
+
+    return (map_log_to_complex,)
 
 
 @app.cell

--- a/chartpuck-circle.py
+++ b/chartpuck-circle.py
@@ -64,21 +64,33 @@ def _(ChartPuck, mo, np, plt):
     return (puck,)
 
 
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Mapping between images
+
+    This notebook is inspired by this 3b1b video and it serves as an interactive way to intuit what is happening.
+
+    Let's start by comparing these two lines. You can move the dot on the left chart. Can you see the relationship?
+    """)
+    return
+
+
 @app.cell
 def _(mo, np, plt, puck):
     from mohtml import div 
 
     px, py = puck.x[0], puck.y[0]
-    r = np.sqrt(px**2 + py**2)
-    theta = np.arctan2(py, px)
-    log_r = np.log(max(r, 1e-9))
+    puck_r = np.sqrt(px**2 + py**2)
+    puck_theta = np.arctan2(py, px)
+    puck_log_r = np.log(max(puck_r, 1e-9))
 
     # The circle (all points at radius r) maps to a vertical line at x = ln(r)
     theta_range = np.linspace(-np.pi, np.pi, 200)
 
     fig, ax = plt.subplots(figsize=(6, 6))
-    ax.plot(np.full_like(theta_range, log_r), theta_range, color="#e63946", linewidth=2)
-    ax.plot(log_r, theta, "o", color="#e63946", markersize=8)
+    ax.plot(np.full_like(theta_range, puck_log_r), theta_range, color="#e63946", linewidth=2)
+    ax.plot(puck_log_r, puck_theta, "o", color="#e63946", markersize=8)
     ax.axhline(0, color="black", linewidth=0.5)
     ax.axvline(0, color="black", linewidth=0.5)
     ax.grid(True, alpha=0.3)
@@ -95,41 +107,75 @@ def _(mo, np, plt, puck):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
+    When you keep the circle in the same size and move the puck over it you'll see that is like changing an angle. And this is reflecting in the image to the right because the dot moves on the `y`-axis. When you change the radius though, you can see movement on the `x`-axis.
+
     But what if we apply a mapping of an entire image using this technique?
     """)
     return
 
 
 @app.cell
-def _(div, log_img, map_log_to_complex, mo, np, plt, puck):
+def _(ChartPuck, log_img, map_log_to_complex, mo, np, plt):
     arr = np.array(log_img)
     mapped = map_log_to_complex(arr)
 
-    puck_x, puck_y = puck.x[0], puck.y[0]
-    puck_r = np.sqrt(puck_x**2 + puck_y**2)
+    def draw_mapped_with_circle(ax, widget):
+        ax.imshow(mapped, extent=(-5, 5, -5, 5), origin="lower")
+        px, py = widget.x[0], widget.y[0]
+        r = np.sqrt(px**2 + py**2)
+        circle = plt.Circle((0, 0), r, fill=False, color="#e63946", linewidth=2)
+        ax.add_patch(circle)
+        ax.set_xlim(-5, 5)
+        ax.set_ylim(-5, 5)
+        ax.set_aspect("equal")
 
-    fig_mapped, ax_mapped = plt.subplots(figsize=(6, 6))
-    ax_mapped.imshow(mapped, extent=(-5, 5, -5, 5), origin="lower")
-    circle = plt.Circle((0, 0), puck_r, fill=False, color="#e63946", linewidth=2)
-    ax_mapped.add_patch(circle)
-    ax_mapped.plot(puck_x, puck_y, "o", color="#e63946", markersize=10, zorder=5)
-    ax_mapped.set_xlim(-5, 5)
-    ax_mapped.set_ylim(-5, 5)
-    ax_mapped.set_aspect("equal")
+    log_puck = mo.ui.anywidget(
+        ChartPuck.from_callback(
+            draw_fn=draw_mapped_with_circle,
+            x_bounds=(-5, 5),
+            y_bounds=(-5, 5),
+            figsize=(6, 6),
+            x=2.0,
+            y=0.0,
+            puck_radius=6,
+            throttle=100,
+        )
+    )
+    return arr, log_puck
+
+
+@app.cell
+def _(arr, div, log_puck, mo, np, plt):
+    lp_x, lp_y = log_puck.x[0], log_puck.y[0]
+    lp_r = np.sqrt(lp_x**2 + lp_y**2)
+    log_r = np.log(max(lp_r, 1e-9))
+    lp_theta = np.arctan2(lp_y, lp_x)
+    angles = np.linspace(-np.pi, np.pi, 200)
 
     fig_log, ax_log = plt.subplots(figsize=(6, 6))
     ax_log.imshow(arr, extent=(-2, 2, -np.pi, np.pi), origin="lower", aspect="auto")
-    log_puck_r = np.log(max(puck_r, 1e-9))
-    angles = np.linspace(-np.pi, np.pi, 200)
-    ax_log.plot(np.full_like(angles, log_puck_r), angles, color="#e63946", linewidth=2)
-    puck_theta = np.arctan2(puck_y, puck_x)
-    ax_log.plot(log_puck_r, puck_theta, "o", color="#e63946", markersize=10, zorder=5)
+    ax_log.plot(np.full_like(angles, log_r), angles, color="#e63946", linewidth=2)
+    ax_log.plot(log_r, lp_theta, "o", color="#e63946", markersize=10, zorder=5)
     ax_log.set_xlim(-2, 2)
     ax_log.set_ylim(-np.pi, np.pi)
     ax_log.set_xlabel("ln(r)")
     ax_log.set_ylabel("θ")
 
-    mo.hstack([div(style="padding-left: 19px;"), fig_mapped, div(style="padding-left: 28px;"), mo.vstack([fig_log])], justify="start")
+    mo.hstack([log_puck, mo.vstack([div(style="margin-top: 37px;"), fig_log])], justify="start")
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    Things can feel quite "trippy" but the main thing to remember here is that we're "just" doing a mapping. The chart on the right is transformed just like the red line.
+
+    ## Different projections.
+
+    By now you may recognize that the mapping has a relationship to complex numbers. These live in "polar coordinate"-land and can sometimes cause behavior that feels strange at first but make some sense when you start thinging about it.
+
+    In the next section, you'll explore a point with a radius and you're able to select different functions in the complex plane to get an impression of how the underlying data is transformed.
+    """)
     return
 
 
@@ -268,6 +314,7 @@ def _(apply_mapping, np):
 def _(
     bounds,
     colors,
+    div,
     draw_mapped_circles,
     mapping_dropdown,
     mapping_puck,
@@ -289,7 +336,7 @@ def _(
     ax_out.set_aspect("equal")
     ax_out.set_title(f"Output: f(z) = {mapping_dropdown.value}")
 
-    mo.hstack([mapping_puck, fig_out], justify="start")
+    mo.hstack([mapping_puck, mo.vstack([div(style="padding-top: 22px;"), fig_out])], justify="start")
     return
 
 
@@ -394,45 +441,72 @@ def _(np):
             ax.plot(cx + rad * np.cos(t), cy + rad * np.sin(t), color=col, linewidth=2)
         ax.plot(cx, cy, "o", color="#e63946", markersize=10, zorder=5)
 
-    return (draw_input_circles_on,)
+    return
+
+
+@app.cell
+def _(ChartPuck, colors, make_texture, mo, np, radii, texture_dropdown):
+    texture = make_texture(texture_dropdown.value)
+
+    def draw_texture_with_circles(ax, widget):
+        ax.imshow(texture, extent=(-5, 5, -5, 5), origin="lower")
+        cx, cy = widget.x[0], widget.y[0]
+        t = np.linspace(0, 2 * np.pi, 200)
+        for rad, col in zip(radii, colors):
+            ax.plot(cx + rad * np.cos(t), cy + rad * np.sin(t), color=col, linewidth=2)
+        ax.set_xlim(-5, 5)
+        ax.set_ylim(-5, 5)
+        ax.set_aspect("equal")
+        ax.set_title("Input texture")
+
+    texture_puck = mo.ui.anywidget(
+        ChartPuck.from_callback(
+            draw_fn=draw_texture_with_circles,
+            x_bounds=(-5, 5),
+            y_bounds=(-5, 5),
+            figsize=(6, 6),
+            x=2.0,
+            y=1.0,
+            puck_radius=6,
+            throttle=100,
+        )
+    )
+    return texture, texture_puck
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    Let's now repeat the exercise but with an image at the bottom of it. The results can be quite unexpected!
+    """)
+    return
 
 
 @app.cell
 def _(
     colors,
     div,
-    draw_input_circles_on,
     draw_mapped_circles,
-    make_texture,
     map_image_through,
     mapping_dropdown,
-    mapping_puck,
     mo,
     plt,
     radii,
-    texture_dropdown,
+    texture,
+    texture_puck,
 ):
-    texture = make_texture(texture_dropdown.value)
     mapped_texture = map_image_through(texture, mapping_dropdown.value)
-    mcx, mcy = mapping_puck.x[0], mapping_puck.y[0]
-
-    fig_src, ax_src = plt.subplots(figsize=(6, 6))
-    ax_src.imshow(texture, extent=(-5, 5, -5, 5), origin="lower")
-    draw_input_circles_on(ax_src, mcx, mcy, radii, colors)
-    ax_src.set_xlim(-5, 5)
-    ax_src.set_ylim(-5, 5)
-    ax_src.set_aspect("equal")
-    ax_src.set_title("Input texture")
+    tcx, tcy = texture_puck.x[0], texture_puck.y[0]
 
     fig_dst, ax_dst = plt.subplots(figsize=(6, 6))
     ax_dst.imshow(mapped_texture, extent=(-5, 5, -5, 5), origin="lower")
-    draw_mapped_circles(ax_dst, mcx, mcy, radii, colors, mapping_dropdown.value)
+    draw_mapped_circles(ax_dst, tcx, tcy, radii, colors, mapping_dropdown.value)
     ax_dst.set_xlim(-5, 5)
     ax_dst.set_ylim(-5, 5)
     ax_dst.set_aspect("equal")
     ax_dst.set_title(f"Mapped texture: {mapping_dropdown.value}")
 
-    mo.hstack([div(style="padding-left: 19px;"), fig_src, div(style="padding-left: 28px;"), fig_dst], justify="start")
+    mo.hstack([texture_puck, mo.vstack([div(style="padding-top: 21px;"), fig_dst])], justify="start")
     return
 
 

--- a/chartpuck-circle.py
+++ b/chartpuck-circle.py
@@ -22,6 +22,7 @@ def _():
     import marimo as mo
     import numpy as np
     import matplotlib
+
     matplotlib.rcParams["figure.dpi"] = 72
     import matplotlib.pyplot as plt
     from wigglystuff import ChartPuck
@@ -33,6 +34,7 @@ def _():
 def _(ChartPuck, mo, np, plt):
     x_bounds = (-5, 5)
     y_bounds = (-5, 5)
+
 
     def draw_circle(ax, widget):
         px, py = widget.x[0], widget.y[0]
@@ -48,6 +50,7 @@ def _(ChartPuck, mo, np, plt):
         ax.set_ylim(y_bounds)
         ax.set_aspect("equal")
         ax.set_title("")
+
 
     puck = mo.ui.anywidget(
         ChartPuck.from_callback(
@@ -78,7 +81,7 @@ def _(mo):
 
 @app.cell
 def _(mo, np, plt, puck):
-    from mohtml import div 
+    from mohtml import div
 
     px, py = puck.x[0], puck.y[0]
     puck_r = np.sqrt(px**2 + py**2)
@@ -119,6 +122,7 @@ def _(ChartPuck, log_img, map_log_to_complex, mo, np, plt):
     arr = np.array(log_img)
     mapped = map_log_to_complex(arr)
 
+
     def draw_mapped_with_circle(ax, widget):
         ax.imshow(mapped, extent=(-5, 5, -5, 5), origin="lower")
         px, py = widget.x[0], widget.y[0]
@@ -128,6 +132,7 @@ def _(ChartPuck, log_img, map_log_to_complex, mo, np, plt):
         ax.set_xlim(-5, 5)
         ax.set_ylim(-5, 5)
         ax.set_aspect("equal")
+
 
     log_puck = mo.ui.anywidget(
         ChartPuck.from_callback(
@@ -198,6 +203,7 @@ def _(Image, ImageDraw):
                     draw.rectangle([col, row, col + tile_size, row + tile_size], fill="#b0b0b0")
         return img
 
+
     log_img = make_checkerboard()
     return (log_img,)
 
@@ -245,7 +251,7 @@ def _(mo):
 def _(np):
     def apply_mapping(z, name):
         if name == "z_squared":
-            return z ** 2
+            return z**2
         elif name == "inversion":
             return 1.0 / np.where(np.abs(z) < 1e-9, 1e-9, z)
         elif name == "joukowski":
@@ -267,6 +273,7 @@ def _(ChartPuck, mo, np):
     colors = ["#e63946", "#457b9d", "#2a9d8f"]
     n_pts = 200
 
+
     def draw_input_circles(ax, widget):
         cx, cy = widget.x[0], widget.y[0]
         t = np.linspace(0, 2 * np.pi, n_pts)
@@ -279,6 +286,7 @@ def _(ChartPuck, mo, np):
         ax.set_ylim(bounds)
         ax.set_aspect("equal")
         ax.set_title("Input: z")
+
 
     mapping_puck = mo.ui.anywidget(
         ChartPuck.from_callback(
@@ -305,7 +313,9 @@ def _(apply_mapping, np):
             z_out = apply_mapping(z_in, mapping_name)
             ax.plot(z_out.real, z_out.imag, color=col, linewidth=2)
         center_mapped = apply_mapping(cx + 1j * cy, mapping_name)
-        ax.plot(center_mapped.real, center_mapped.imag, "o", color="#e63946", markersize=10, zorder=5)
+        ax.plot(
+            center_mapped.real, center_mapped.imag, "o", color="#e63946", markersize=10, zorder=5
+        )
 
     return (draw_mapped_circles,)
 
@@ -325,8 +335,11 @@ def _(
     fig_out, ax_out = plt.subplots(figsize=(6, 6))
     draw_mapped_circles(
         ax_out,
-        mapping_puck.x[0], mapping_puck.y[0],
-        radii, colors, mapping_dropdown.value,
+        mapping_puck.x[0],
+        mapping_puck.y[0],
+        radii,
+        colors,
+        mapping_dropdown.value,
     )
     ax_out.axhline(0, color="black", linewidth=0.5)
     ax_out.axvline(0, color="black", linewidth=0.5)
@@ -336,13 +349,21 @@ def _(
     ax_out.set_aspect("equal")
     ax_out.set_title(f"Output: f(z) = {mapping_dropdown.value}")
 
-    mo.hstack([mapping_puck, mo.vstack([div(style="padding-top: 22px;"), fig_out])], justify="start")
+    mo.hstack(
+        [mapping_puck, mo.vstack([div(style="padding-top: 22px;"), fig_out])], justify="start"
+    )
     return
 
 
 @app.cell
-def _(mapping_dropdown, mo, texture_dropdown):
-    mo.hstack([mapping_dropdown, texture_dropdown], justify="start")
+def _(mo):
+    wrap_checkbox = mo.ui.checkbox(value=False, label="Wrap texture (tiling effect)")
+    return (wrap_checkbox,)
+
+
+@app.cell
+def _(mapping_dropdown, mo, texture_dropdown, wrap_checkbox):
+    mo.hstack([mapping_dropdown, texture_dropdown, wrap_checkbox], justify="start")
     return
 
 
@@ -385,7 +406,9 @@ def _(Image, ImageDraw, np):
             draw = ImageDraw.Draw(img)
             cx, cy = width // 2, height // 2
             for ring in range(20, max(width, height), 40):
-                draw.ellipse([cx - ring, cy - ring, cx + ring, cy + ring], outline="#457b9d", width=1)
+                draw.ellipse(
+                    [cx - ring, cy - ring, cx + ring, cy + ring], outline="#457b9d", width=1
+                )
             for angle_deg in range(0, 360, 30):
                 angle = np.radians(angle_deg)
                 ex = int(cx + max(width, height) * np.cos(angle))
@@ -397,7 +420,7 @@ def _(Image, ImageDraw, np):
 
 
 @app.cell
-def _(map_coordinates, np):
+def _(map_coordinates, np, wrap_checkbox):
     def map_image_through(img_arr, mapping_name, output_size=400, plane_bounds=(-5, 5)):
         h, w = img_arr.shape[:2]
         lin = np.linspace(plane_bounds[0], plane_bounds[1], output_size)
@@ -423,9 +446,16 @@ def _(map_coordinates, np):
         px_x = (src.real - plane_bounds[0]) / (plane_bounds[1] - plane_bounds[0]) * w
         px_y = (src.imag - plane_bounds[0]) / (plane_bounds[1] - plane_bounds[0]) * h
 
-        # Mask for pixels that map to valid input coordinates
-        valid = (px_x >= 0) & (px_x < w) & (px_y >= 0) & (px_y < h) & np.isfinite(px_x) & np.isfinite(px_y)
+        if wrap_checkbox.value:
+            # Wrap mode: image tiles seamlessly outside bounds
+            channels = []
+            for i in range(3):
+                ch = map_coordinates(img_arr[..., i], [px_y, px_x], order=1, mode="wrap")
+                channels.append(ch)
+            return np.stack(channels, axis=-1)
 
+        # Transparent mode: out-of-bounds pixels become transparent
+        valid = (px_x >= 0) & (px_x < w) & (px_y >= 0) & (px_y < h) & np.isfinite(px_x) & np.isfinite(px_y)
         channels = []
         for i in range(3):
             ch = map_coordinates(img_arr[..., i], [px_y, px_x], order=1, mode="constant", cval=0)
@@ -452,6 +482,7 @@ def _(np):
 def _(ChartPuck, colors, make_texture, mo, np, radii, texture_dropdown):
     texture = make_texture(texture_dropdown.value)
 
+
     def draw_texture_with_circles(ax, widget):
         ax.imshow(texture, extent=(-5, 5, -5, 5), origin="lower")
         cx, cy = widget.x[0], widget.y[0]
@@ -462,6 +493,7 @@ def _(ChartPuck, colors, make_texture, mo, np, radii, texture_dropdown):
         ax.set_ylim(-5, 5)
         ax.set_aspect("equal")
         ax.set_title("Input texture")
+
 
     texture_puck = mo.ui.anywidget(
         ChartPuck.from_callback(
@@ -510,7 +542,59 @@ def _(
     ax_dst.set_aspect("equal")
     ax_dst.set_title(f"Mapped texture: {mapping_dropdown.value}")
 
-    mo.hstack([texture_puck, mo.vstack([div(style="padding-top: 21px;"), fig_dst])], justify="start")
+    mo.hstack(
+        [texture_puck, mo.vstack([div(style="padding-top: 21px;"), fig_dst])], justify="start"
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    With `1/z` on a checkerboard, you can zoom in near the origin and see the pattern repeat infinitely — a hallmark of conformal inversion.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    zoom_slider = mo.ui.slider(0.1, 5.0, step=0.05, value=5.0, label="Zoom (half-width)")
+    return (zoom_slider,)
+
+
+@app.cell
+def _(make_texture, map_image_through, mo, plt, zoom_slider):
+    zoom_half = zoom_slider.value
+    zoom_bounds = (-zoom_half, zoom_half)
+
+    checker = make_texture("checkerboard")
+    zoomed = map_image_through(checker, "inversion", output_size=500, plane_bounds=zoom_bounds)
+
+    fig_zoom, ax_zoom = plt.subplots(figsize=(8, 8))
+    ax_zoom.imshow(zoomed, extent=(*zoom_bounds, *zoom_bounds), origin="lower")
+    ax_zoom.axhline(0, color="white", linewidth=0.5, alpha=0.5)
+    ax_zoom.axvline(0, color="white", linewidth=0.5, alpha=0.5)
+    ax_zoom.set_xlim(zoom_bounds)
+    ax_zoom.set_ylim(zoom_bounds)
+    ax_zoom.set_aspect("equal")
+    ax_zoom.set_title(f"1/z on checkerboard — zoom: {zoom_half:.2f}")
+
+    mo.vstack([zoom_slider, fig_zoom])
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Appendix: What does "Wrap texture" do?
+
+    When we map an image through a complex function, many output pixels trace back to source coordinates that fall outside the original image bounds. The **"Wrap texture"** checkbox controls what happens at those out-of-bounds pixels.
+
+    - **Unchecked (default):** Out-of-bounds pixels become transparent. Only the region that maps back into the original image is visible, giving you a clear view of where the mapping is well-defined.
+    - **Checked:** Out-of-bounds coordinates wrap around modulo the image size (e.g. coordinate 450 on a 400px image becomes 50, and -3 becomes 397). This effectively tiles the image infinitely in all directions, so the complex mapping produces a seamless, repeating pattern — which is where the "trippy" infinite-tiling effect comes from.
+
+    Under the hood this is controlled by the `mode` parameter of `scipy.ndimage.map_coordinates`: `mode="wrap"` for tiling, `mode="constant"` with an alpha mask for transparency.
+    """)
     return
 
 

--- a/chartpuck-circle.py
+++ b/chartpuck-circle.py
@@ -1,0 +1,99 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "marimo",
+#     "numpy",
+#     "matplotlib",
+#     "wigglystuff",
+#     "mohtml==0.1.11",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.21.1"
+app = marimo.App(width="full")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    import numpy as np
+    import matplotlib
+    matplotlib.rcParams["figure.dpi"] = 72
+    import matplotlib.pyplot as plt
+    from wigglystuff import ChartPuck
+
+    return ChartPuck, mo, np, plt
+
+
+@app.cell
+def _(ChartPuck, mo, np, plt):
+    x_bounds = (-5, 5)
+    y_bounds = (-5, 5)
+
+    def draw_circle(ax, widget):
+        px, py = widget.x[0], widget.y[0]
+        r = np.sqrt(px**2 + py**2)
+
+        circle = plt.Circle((0, 0), r, fill=False, color="#e63946", linewidth=2)
+        ax.add_patch(circle)
+
+        ax.axhline(0, color="black", linewidth=0.5)
+        ax.axvline(0, color="black", linewidth=0.5)
+        ax.grid(True, alpha=0.3)
+        ax.set_xlim(x_bounds)
+        ax.set_ylim(y_bounds)
+        ax.set_aspect("equal")
+        ax.set_title("Complex Plane")
+
+    puck = mo.ui.anywidget(
+        ChartPuck.from_callback(
+            draw_fn=draw_circle,
+            x_bounds=x_bounds,
+            y_bounds=y_bounds,
+            figsize=(6, 6),
+            x=2.0,
+            y=0.0,
+            puck_radius=6,
+            throttle=100,
+        )
+    )
+    return (puck,)
+
+
+@app.cell
+def _(mo, np, plt, puck):
+    from mohtml import div 
+
+    px, py = puck.x[0], puck.y[0]
+    r = np.sqrt(px**2 + py**2)
+    theta = np.arctan2(py, px)
+    log_r = np.log(max(r, 1e-9))
+
+    # The circle (all points at radius r) maps to a vertical line at x = ln(r)
+    theta_range = np.linspace(-np.pi, np.pi, 200)
+
+    fig, ax = plt.subplots(figsize=(6, 6))
+    ax.plot(np.full_like(theta_range, log_r), theta_range, color="#e63946", linewidth=2)
+    ax.plot(log_r, theta, "o", color="#e63946", markersize=8)
+    ax.axhline(0, color="black", linewidth=0.5)
+    ax.axvline(0, color="black", linewidth=0.5)
+    ax.grid(True, alpha=0.3)
+    ax.set_xlim(-2, 2)
+    ax.set_ylim(-np.pi, np.pi)
+    ax.set_xlabel("ln(r)")
+    ax.set_ylabel("θ")
+    ax.set_title("Log Space")
+
+    mo.hstack([puck, mo.vstack([div(style="margin-top: 21px;"), fig])], justify="start")
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/chartpuck-circle.py
+++ b/chartpuck-circle.py
@@ -17,17 +17,16 @@ __generated_with = "0.21.1"
 app = marimo.App(width="full")
 
 
-app._unparsable_cell(
-    r"""
-    jimport marimo as mo
+@app.cell
+def _():
+    import marimo as mo
     import numpy as np
     import matplotlib
     matplotlib.rcParams["figure.dpi"] = 72
     import matplotlib.pyplot as plt
     from wigglystuff import ChartPuck
-    """,
-    name="_"
-)
+
+    return ChartPuck, mo, np, plt
 
 
 @app.cell
@@ -150,7 +149,7 @@ def _(Image, ImageDraw):
         for row in range(0, height, tile_size):
             for col in range(0, width, tile_size):
                 if (row // tile_size + col // tile_size) % 2 == 0:
-                    draw.rectangle([col, row, col + tile_size, row + tile_size], fill="#1f77b4")
+                    draw.rectangle([col, row, col + tile_size, row + tile_size], fill="#b0b0b0")
         return img
 
     log_img = make_checkerboard()
@@ -181,7 +180,259 @@ def _(map_coordinates, np):
 
 
 @app.cell
-def _():
+def _(mo):
+    mapping_dropdown = mo.ui.dropdown(
+        options={
+            "z²": "z_squared",
+            "1/z": "inversion",
+            "z + 1/z (Joukowski)": "joukowski",
+            "e^z": "exp",
+            "log(z)": "log",
+        },
+        value="z²",
+        label="Mapping",
+    )
+    return (mapping_dropdown,)
+
+
+@app.cell
+def _(np):
+    def apply_mapping(z, name):
+        if name == "z_squared":
+            return z ** 2
+        elif name == "inversion":
+            return 1.0 / np.where(np.abs(z) < 1e-9, 1e-9, z)
+        elif name == "joukowski":
+            safe_z = np.where(np.abs(z) < 1e-9, 1e-9, z)
+            return safe_z + 1.0 / safe_z
+        elif name == "exp":
+            return np.exp(z)
+        elif name == "log":
+            return np.log(np.where(np.abs(z) < 1e-9, 1e-9, z) + 0j)
+        return z
+
+    return (apply_mapping,)
+
+
+@app.cell
+def _(ChartPuck, mo, np):
+    bounds = (-5, 5)
+    radii = [0.3, 0.6, 1.0]
+    colors = ["#e63946", "#457b9d", "#2a9d8f"]
+    n_pts = 200
+
+    def draw_input_circles(ax, widget):
+        cx, cy = widget.x[0], widget.y[0]
+        t = np.linspace(0, 2 * np.pi, n_pts)
+        for rad, col in zip(radii, colors):
+            ax.plot(cx + rad * np.cos(t), cy + rad * np.sin(t), color=col, linewidth=2)
+        ax.axhline(0, color="black", linewidth=0.5)
+        ax.axvline(0, color="black", linewidth=0.5)
+        ax.grid(True, alpha=0.3)
+        ax.set_xlim(bounds)
+        ax.set_ylim(bounds)
+        ax.set_aspect("equal")
+        ax.set_title("Input: z")
+
+    mapping_puck = mo.ui.anywidget(
+        ChartPuck.from_callback(
+            draw_fn=draw_input_circles,
+            x_bounds=bounds,
+            y_bounds=bounds,
+            figsize=(6, 6),
+            x=2.0,
+            y=1.0,
+            puck_radius=6,
+            throttle=100,
+        )
+    )
+    return bounds, colors, mapping_puck, radii
+
+
+@app.cell
+def _(apply_mapping, np):
+    def draw_mapped_circles(ax, cx, cy, radii, colors, mapping_name, n_pts=200):
+        """Draw circles centered at (cx, cy) mapped through a function onto ax."""
+        t = np.linspace(0, 2 * np.pi, n_pts)
+        for rad, col in zip(radii, colors):
+            z_in = (cx + rad * np.cos(t)) + 1j * (cy + rad * np.sin(t))
+            z_out = apply_mapping(z_in, mapping_name)
+            ax.plot(z_out.real, z_out.imag, color=col, linewidth=2)
+        center_mapped = apply_mapping(cx + 1j * cy, mapping_name)
+        ax.plot(center_mapped.real, center_mapped.imag, "o", color="#e63946", markersize=10, zorder=5)
+
+    return (draw_mapped_circles,)
+
+
+@app.cell
+def _(
+    bounds,
+    colors,
+    draw_mapped_circles,
+    mapping_dropdown,
+    mapping_puck,
+    mo,
+    plt,
+    radii,
+):
+    fig_out, ax_out = plt.subplots(figsize=(6, 6))
+    draw_mapped_circles(
+        ax_out,
+        mapping_puck.x[0], mapping_puck.y[0],
+        radii, colors, mapping_dropdown.value,
+    )
+    ax_out.axhline(0, color="black", linewidth=0.5)
+    ax_out.axvline(0, color="black", linewidth=0.5)
+    ax_out.grid(True, alpha=0.3)
+    ax_out.set_xlim(bounds)
+    ax_out.set_ylim(bounds)
+    ax_out.set_aspect("equal")
+    ax_out.set_title(f"Output: f(z) = {mapping_dropdown.value}")
+
+    mo.hstack([mapping_puck, fig_out], justify="start")
+    return
+
+
+@app.cell
+def _(mapping_dropdown, mo, texture_dropdown):
+    mo.hstack([mapping_dropdown, texture_dropdown], justify="start")
+    return
+
+
+@app.cell
+def _(mo):
+    texture_dropdown = mo.ui.dropdown(
+        options={
+            "Checkerboard": "checkerboard",
+            "Color Spectrum": "spectrum",
+            "Polar Grid": "polar_grid",
+        },
+        value="Checkerboard",
+        label="Texture",
+    )
+    return (texture_dropdown,)
+
+
+@app.cell
+def _(Image, ImageDraw, np):
+    def make_texture(name, width=400, height=400):
+        if name == "checkerboard":
+            tile_size = 50
+            img = Image.new("RGB", (width, height), "white")
+            draw = ImageDraw.Draw(img)
+            for row in range(0, height, tile_size):
+                for col in range(0, width, tile_size):
+                    if (row // tile_size + col // tile_size) % 2 == 0:
+                        draw.rectangle([col, row, col + tile_size, row + tile_size], fill="#b0b0b0")
+            return np.array(img)
+        elif name == "spectrum":
+            x = np.linspace(0, 1, width)
+            y = np.linspace(0, 1, height)
+            gx, gy = np.meshgrid(x, y)
+            r = (255 * gx).astype(np.uint8)
+            g = (255 * gy).astype(np.uint8)
+            b = (255 * (1 - gx)).astype(np.uint8)
+            return np.stack([r, g, b], axis=-1)
+        elif name == "polar_grid":
+            img = Image.new("RGB", (width, height), "white")
+            draw = ImageDraw.Draw(img)
+            cx, cy = width // 2, height // 2
+            for ring in range(20, max(width, height), 40):
+                draw.ellipse([cx - ring, cy - ring, cx + ring, cy + ring], outline="#457b9d", width=1)
+            for angle_deg in range(0, 360, 30):
+                angle = np.radians(angle_deg)
+                ex = int(cx + max(width, height) * np.cos(angle))
+                ey = int(cy + max(width, height) * np.sin(angle))
+                draw.line([(cx, cy), (ex, ey)], fill="#457b9d", width=1)
+            return np.array(img)
+
+    return (make_texture,)
+
+
+@app.cell
+def _(map_coordinates, np):
+    def map_image_through(img_arr, mapping_name, output_size=400, plane_bounds=(-5, 5)):
+        h, w = img_arr.shape[:2]
+        lin = np.linspace(plane_bounds[0], plane_bounds[1], output_size)
+        gx, gy = np.meshgrid(lin, lin)
+        z = gx + 1j * gy
+
+        if mapping_name == "z_squared":
+            src = np.sqrt(z + 0j)
+        elif mapping_name == "inversion":
+            safe_z = np.where(np.abs(z) < 1e-9, 1e-9, z)
+            src = 1.0 / safe_z
+        elif mapping_name == "joukowski":
+            # Inverse of w = z + 1/z is z = (w ± sqrt(w²-4))/2
+            disc = np.sqrt(z**2 - 4 + 0j)
+            src = (z + disc) / 2
+        elif mapping_name == "exp":
+            src = np.log(z + 0j)
+        elif mapping_name == "log":
+            src = np.exp(z)
+        else:
+            src = z
+
+        px_x = (src.real - plane_bounds[0]) / (plane_bounds[1] - plane_bounds[0]) * w
+        px_y = (src.imag - plane_bounds[0]) / (plane_bounds[1] - plane_bounds[0]) * h
+
+        channels = []
+        for i in range(3):
+            ch = map_coordinates(img_arr[..., i], [px_y, px_x], order=1, mode="wrap")
+            channels.append(ch)
+        return np.stack(channels, axis=-1)
+
+    return (map_image_through,)
+
+
+@app.cell
+def _(np):
+    def draw_input_circles_on(ax, cx, cy, radii, colors, n_pts=200):
+        """Draw concentric circles centered at (cx, cy) on ax."""
+        t = np.linspace(0, 2 * np.pi, n_pts)
+        for rad, col in zip(radii, colors):
+            ax.plot(cx + rad * np.cos(t), cy + rad * np.sin(t), color=col, linewidth=2)
+        ax.plot(cx, cy, "o", color="#e63946", markersize=10, zorder=5)
+
+    return (draw_input_circles_on,)
+
+
+@app.cell
+def _(
+    colors,
+    div,
+    draw_input_circles_on,
+    draw_mapped_circles,
+    make_texture,
+    map_image_through,
+    mapping_dropdown,
+    mapping_puck,
+    mo,
+    plt,
+    radii,
+    texture_dropdown,
+):
+    texture = make_texture(texture_dropdown.value)
+    mapped_texture = map_image_through(texture, mapping_dropdown.value)
+    mcx, mcy = mapping_puck.x[0], mapping_puck.y[0]
+
+    fig_src, ax_src = plt.subplots(figsize=(6, 6))
+    ax_src.imshow(texture, extent=(-5, 5, -5, 5), origin="lower")
+    draw_input_circles_on(ax_src, mcx, mcy, radii, colors)
+    ax_src.set_xlim(-5, 5)
+    ax_src.set_ylim(-5, 5)
+    ax_src.set_aspect("equal")
+    ax_src.set_title("Input texture")
+
+    fig_dst, ax_dst = plt.subplots(figsize=(6, 6))
+    ax_dst.imshow(mapped_texture, extent=(-5, 5, -5, 5), origin="lower")
+    draw_mapped_circles(ax_dst, mcx, mcy, radii, colors, mapping_dropdown.value)
+    ax_dst.set_xlim(-5, 5)
+    ax_dst.set_ylim(-5, 5)
+    ax_dst.set_aspect("equal")
+    ax_dst.set_title(f"Mapped texture: {mapping_dropdown.value}")
+
+    mo.hstack([div(style="padding-left: 19px;"), fig_src, div(style="padding-left: 28px;"), fig_dst], justify="start")
     return
 
 

--- a/conformal-mapping.py
+++ b/conformal-mapping.py
@@ -1,0 +1,247 @@
+# /// script
+# dependencies = [
+#     "marimo",
+#     "matplotlib==3.10.8",
+#     "numpy==2.4.3",
+#     "wigglystuff==0.2.40",
+# ]
+# requires-python = ">=3.12"
+# ///
+
+import marimo
+
+__generated_with = "0.21.1"
+app = marimo.App(width="columns", sql_output="polars")
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell
+def _():
+    import numpy as np
+    import matplotlib.pyplot as plt
+
+
+    def generate_checkerboard(grid_size=512, squares=8):
+        """Generates a grayscale checkerboard pattern."""
+        x = np.linspace(-1, 1, grid_size)
+        y = np.linspace(-1, 1, grid_size)
+        X, Y = np.meshgrid(x, y)
+
+        # Logic: (x_index + y_index) % 2
+        # We scale by 'squares' to determine density
+        checker = (np.floor(X * squares) + np.floor(Y * squares)) % 2
+
+        # Add a small dot at the origin to track movement
+        center_mask = (X**2 + Y**2) < 0.01
+        checker = np.where(center_mask, 0.5, checker)
+
+        return checker
+
+
+    def generate_uv_map(grid_size=512):
+        """Generates a color map where Red=X and Green=Y."""
+        x = np.linspace(0, 1, grid_size)
+        y = np.linspace(0, 1, grid_size)
+        X, Y = np.meshgrid(x, y)
+
+        # Create an RGB image (Height, Width, 3)
+        uv_image = np.zeros((grid_size, grid_size, 3))
+        uv_image[..., 0] = X  # Red channel
+        uv_image[..., 1] = Y  # Green channel
+        uv_image[..., 2] = 0.5  # Blue (constant)
+
+        return uv_image
+
+    return generate_checkerboard, generate_uv_map, np, plt
+
+
+@app.cell
+def _(generate_checkerboard, generate_uv_map, mo, plt):
+    # Generate textures
+    check = generate_checkerboard()
+    uv = generate_uv_map()
+
+    # Display
+    def plot_two_imgs(check, uv):
+        fig, ax = plt.subplots(1, 2, figsize=(10, 5))
+        ax[0].imshow(check, cmap="gray", extent=[-1, 1, -1, 1])
+        ax[0].set_title("Checkerboard (Structure)")
+        ax[1].imshow(uv, extent=[0, 1, 0, 1])
+        ax[1].set_title("UV Map (Direction/Flow)")
+        return mo.as_html(fig)
+
+    plot_two_imgs(check, uv)
+    return check, plot_two_imgs, uv
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Field notes: Complex Arrays
+
+    It turns out that numpy supports complex number arrays!
+    """)
+    return
+
+
+@app.cell
+def _(np):
+    _ = np.linspace(1, 10, 10)
+    np.exp(_ + 1j)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    This lets us do some amazing things.
+    """)
+    return
+
+
+@app.cell
+def _(np):
+    res = 512 
+    u = np.linspace(-2, 1, res)      # "Zoom" level (log-radius)
+    v = np.linspace(-np.pi, np.pi, res) # Rotation (angle)
+    U, V = np.meshgrid(u, v)
+    W = U + 1j*V
+
+    Z = np.exp(W)
+
+    # 3. Pull colors from the checkerboard (z-plane)
+    z_real, z_imag = np.real(Z), np.imag(Z)
+    mask = (np.abs(z_real) <= 1) & (np.abs(z_imag) <= 1)
+    mask
+    return (mask,)
+
+
+@app.cell
+def _(mask):
+    mask
+    return
+
+
+@app.cell
+def _(check, np, plot_two_imgs, uv):
+    def apply_map(texture, mapper, res=512, *args, **kwargs):
+        u = np.linspace(-2, 1, res)      # "Zoom" level (log-radius)
+        v = np.linspace(-np.pi, np.pi, res) # Rotation (angle)
+        U, V = np.meshgrid(u, v)
+        W = U + 1j*V
+
+        # This is where the function is actually applied
+        Z = mapper(W, *args, **kwargs)
+
+        z_real, z_imag = np.real(Z), np.imag(Z)
+        mask = (np.abs(z_real) <= 1) & (np.abs(z_imag) <= 1)
+
+        tex_y = ((z_imag + 1) / 2 * (texture.shape[0] - 1)).astype(int)
+        tex_x = ((z_real + 1) / 2 * (texture.shape[1] - 1)).astype(int)
+
+        output = np.zeros_like(texture)
+        output[mask] = texture[tex_y[mask], tex_x[mask]]
+        return output
+
+    def apply_log_map(texture, res=512):
+        # 1. Create the w-plane (Rectangular canvas)
+        # x maps to ln(r), y maps to theta
+        u = np.linspace(-2, 1, res)      # "Zoom" level (log-radius)
+        v = np.linspace(-np.pi, np.pi, res) # Rotation (angle)
+        U, V = np.meshgrid(u, v)
+        W = U + 1j*V
+
+        # 2. Inverse map: z = exp(w)
+        Z = np.exp(W)
+
+        # 3. Pull colors from the checkerboard (z-plane)
+        z_real, z_imag = np.real(Z), np.imag(Z)
+        mask = (np.abs(z_real) <= 1) & (np.abs(z_imag) <= 1)
+
+        # Map [-1, 1] coords to [0, res-1] pixel indices
+        tex_y = ((z_imag + 1) / 2 * (texture.shape[0] - 1)).astype(int)
+        tex_x = ((z_real + 1) / 2 * (texture.shape[1] - 1)).astype(int)
+
+        output = np.zeros_like(texture)
+        output[mask] = texture[tex_y[mask], tex_x[mask]]
+        return output
+
+    plot_two_imgs(apply_map(check, np.sqrt), apply_map(uv, np.sqrt))
+    return
+
+
+@app.cell
+def _(np, plt):
+    from wigglystuff import ChartPuck
+
+    # 1. The Mapping Logic
+    # We move 'w' (Target) and calculate 'z' (Source)
+    def get_source_point(w_complex):
+        # Let's use the Square Root mapping as our intuition builder
+        return np.sqrt(w_complex)
+
+    def draw_mapping_viz(ax, widget):
+        # 1. Clear the main axis to start fresh
+        ax.axis('off')
+    
+        # 2. Create two actual sub-axes inside the main puck area
+        # [left, bottom, width, height]
+        ax_source = ax.inset_axes([0.0, 0.1, 0.45, 0.8]) # Left side (z)
+        ax_target = ax.inset_axes([0.55, 0.1, 0.45, 0.8]) # Right side (w)
+    
+        # 3. Pull Puck coordinates (w-plane)
+        w_x, w_y = widget.x[0], widget.y[0]
+        w_val = complex(w_x, w_y)
+    
+        # 4. Map back to Source (z-plane)
+        z_val = np.sqrt(w_val)
+    
+        # --- TARGET AXIS (Right) ---
+        ax_target.set_title("Target Canvas (w)")
+        ax_target.set_xlim(-2.5, 2.5); ax_target.set_ylim(-2.5, 2.5)
+        ax_target.grid(True, alpha=0.2)
+        ax_target.axhline(0, color='black', lw=0.5); ax_target.axvline(0, color='black', lw=0.5)
+        # The Puck you move
+        ax_target.scatter(w_x, w_y, color='red', s=100, zorder=5)
+        # Visual "crosshair" for the puck
+        ax_target.axhline(w_y, color='red', alpha=0.2, linestyle='--')
+        ax_target.axvline(w_x, color='red', alpha=0.2, linestyle='--')
+
+        # --- SOURCE AXIS (Left) ---
+        ax_source.set_title("Source Sticker (z)")
+        ax_source.set_xlim(-2.5, 2.5); ax_source.set_ylim(-2.5, 2.5)
+        ax_source.grid(True, alpha=0.2)
+        ax_source.axhline(0, color='black', lw=0.5); ax_source.axvline(0, color='black', lw=0.5)
+    
+        # Draw the "Sticker" (The -1 to 1 bounds)
+        sticker = plt.Rectangle((-1, -1), 2, 2, facecolor='gray', alpha=0.1, edgecolor='blue')
+        ax_source.add_patch(sticker)
+    
+        # The "Ghost" point being sampled
+        ax_source.scatter(z_val.real, z_val.imag, color='blue', s=100, zorder=5)
+        # Visual "crosshair" for the sample point
+        ax_source.axhline(z_val.imag, color='blue', alpha=0.2, linestyle='--')
+        ax_source.axvline(z_val.real, color='blue', alpha=0.2, linestyle='--')
+                      
+    puck = ChartPuck.from_callback(
+        draw_fn=draw_mapping_viz,
+        x_bounds=(-2, 2), y_bounds=(-2, 2), # Puck moves in w-space
+        figsize=(10, 5), x=1.0, y=0.5
+    )
+    puck
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/sliders.py
+++ b/sliders.py
@@ -1,0 +1,175 @@
+# /// script
+# dependencies = [
+#     "marimo",
+#     "mohtml==0.1.11",
+#     "numpy==2.4.3",
+#     "pillow==12.1.1",
+#     "scipy==1.17.1",
+#     "wigglystuff==0.2.40",
+# ]
+# requires-python = ">=3.12"
+# ///
+
+import marimo
+
+__generated_with = "0.21.1"
+app = marimo.App(width="columns", sql_output="polars")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    from wigglystuff import Paint
+
+    return Paint, mo
+
+
+@app.cell
+def _(mo):
+    import numpy as np
+    from PIL import Image, ImageDraw
+    from scipy.ndimage import map_coordinates
+
+    upload = mo.ui.file(kind="button", label="Upload Image", filetypes=[".png"])
+    c_re = mo.ui.slider(0.1, 2.0, step=0.01, value=1.0, label="Scale ($c_{re}$)")
+    c_im = mo.ui.slider(-1.0, 1.0, step=0.01, value=0.0, label="Twist ($c_{im}$)")
+    zoom = mo.ui.slider(0.0, 10.0, step=0.01, value=0.0, label="Zoom Depth")
+    view_mode = mo.ui.radio(["Spiral Space", "Log Space"], value="Spiral Space")
+
+    mo.md(
+        f"""
+        # 3Blue1Brown Droste Mapping
+        Adjust the sliders to "align" the tiles.
+
+        {mo.vstack([upload, view_mode] + [c_re, c_im, zoom], justify="space-around")}
+        """
+    )
+    return (
+        Image,
+        ImageDraw,
+        c_im,
+        c_re,
+        map_coordinates,
+        np,
+        upload,
+        view_mode,
+        zoom,
+    )
+
+
+@app.cell
+def _(get_source, upload):
+    get_source(upload.value)
+    return
+
+
+@app.cell
+def _(Paint, get_source, mo, upload):
+    _src = get_source(upload.value)
+    widget = mo.ui.anywidget(Paint(init_image=_src))
+    widget
+    return (widget,)
+
+
+@app.cell
+def _(Image, ImageDraw, mo, upload):
+    import io 
+
+    @mo.cache
+    def get_source(file_val):
+        if file_val:
+            raw_data = upload.value[0].contents
+
+            # Use io.BytesIO to make it "look" like a file for PIL
+            img = Image.open(io.BytesIO(raw_data)).convert("RGB")
+            # Resize to a manageable size for real-time slider performance
+            img.thumbnail((600, 600))
+            return img
+
+        # Procedural placeholder with alignment markers
+        img = Image.new("RGB", (300, 300), (245, 245, 240))
+        d = ImageDraw.Draw(img)
+        d.rectangle([0, 0, 299, 299], outline="black", width=10) # Outer
+        d.rectangle([100, 100, 200, 200], outline="red", width=5) # Inner
+        d.text((120, 10), "OUTER", fill="black")
+        return img
+
+    return (get_source,)
+
+
+@app.cell
+def _(np, widget):
+    # Prepare the image and its metadata once
+    img_array = np.array(widget.get_pil())
+    h, w, _ = img_array.shape
+    return
+
+
+@app.cell
+def _(
+    Image,
+    c_im,
+    c_re,
+    get_source,
+    map_coordinates,
+    mo,
+    np,
+    upload,
+    view_mode,
+    zoom,
+):
+    @mo.cache
+    def compute_droste(img, cr, ci, z_depth, mode):
+        arr = np.array(img)
+        h, w, _ = arr.shape
+
+        # Grid in [-1, 1]
+        y, x = np.indices((h, w))
+        u, v = (x - w/2) / (w/2), (y - h/2) / (h/2)
+
+        # 1. Log-Polar Coordinates
+        # We add z_depth to the radius to "travel" through the spiral
+        r_log = 0.5 * np.log(u**2 + v**2 + 1e-9) + (z_depth * 2)
+        theta = np.arctan2(v, u)
+
+        # 2. Apply the Complex Linear Map: f(z) = c * z
+        # This is the "Bizarre Log Space" transformation
+        z_real = cr * r_log - ci * theta
+        z_imag = ci * r_log + cr * theta
+
+        if mode == "Log Space":
+            # Visualize the tiled grid
+            map_x = (z_real * (w / 4)) % w
+            map_y = (z_imag / (2 * np.pi) * h) % h
+        else:
+            # 3. Back to Cartesian with Periodic tiling
+            # The modulo on the log-radius creates the infinite nesting
+            r_final = np.exp(z_real % 1.0) 
+            theta_final = z_imag
+
+            map_x = (r_final * np.cos(theta_final) + 1) / 2 * w
+            map_y = (r_final * np.sin(theta_final) + 1) / 2 * h
+
+        # 4. Sampling with boundary handling
+        out = np.stack([
+            map_coordinates(arr[..., i], [map_y % h, map_x % w], order=1) 
+            for i in range(3)
+        ], axis=-1)
+
+        return Image.fromarray(out)
+
+    # --- 4. RENDER LOOP ---
+    src = get_source(upload.value)
+    dst = compute_droste(src, c_re.value, c_im.value, zoom.value, view_mode.value)
+
+    mo.hstack([src, dst], justify="space-around")
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/sliders.py
+++ b/sliders.py
@@ -56,11 +56,18 @@ def _(Image, ImageDraw, io):
 @app.cell
 def _(mo):
     upload = mo.ui.file(kind="button", label="Upload Screenshot")
-    c_re = mo.ui.slider(0.1, 4.0, step=0.01, value=1.0, label="Scale ($c_{re}$)")
-    c_im = mo.ui.slider(-2.0, 2.0, step=0.01, value=0.0, label="Twist ($c_{im}$)")
-    zoom = mo.ui.slider(0.0, 1.0, step=0.01, value=0.0, label="Zoom Depth")
+    c_re = mo.ui.slider(0.1, 7.0, step=0.01, value=1.0, label="Scale ($c_{re}$)")
+    c_im = mo.ui.slider(-7.0, 7.0, step=0.01, value=0.0, label="Twist ($c_{im}$)")
+    zoom = mo.ui.slider(0.0, 10.0, step=0.01, value=0.0, label="Zoom Depth")
     view_mode = mo.ui.radio(["Spiral Space", "Log Space"], value="Spiral Space", label="View")
     return c_im, c_re, upload, view_mode, zoom
+
+
+@app.cell
+def _():
+    from wigglystuff import Paint
+
+    return (Paint,)
 
 
 @app.cell
@@ -114,33 +121,35 @@ def _(Image, map_coordinates, mo, np):
 
 
 @app.cell
-def _(apply_droste, c_im, c_re, get_source_image, mo, upload, view_mode, zoom):
-    src_img = get_source_image(upload.value)
+def _(apply_droste, c_im, c_re, mo, paint, upload, view_mode, zoom):
+    src_img = paint.get_pil()
     res_img = apply_droste(src_img, c_re.value, c_im.value, zoom.value, view_mode.value)
 
     mo.md(
         f"""
         # 3Blue1Brown Droste Simulator
-        {mo.hstack([upload, view_mode], justify="space-between")}
-    
-        ### Controls
-        {mo.hstack([c_re, c_im, zoom], justify="start")}
-    
-        ---
-        ### Transformation Result
-        {mo.hstack([src_img, res_img], justify="space-around")}
-        """
+        {upload}"""
     )
+    return res_img, src_img
+
+
+@app.cell
+def _(Paint, get_source_image, mo, upload):
+    _src_img = get_source_image(upload.value)
+    paint = mo.ui.anywidget(Paint(init_image=_src_img))
+    paint
+    return (paint,)
+
+
+@app.cell
+def _(c_im, c_re, mo, view_mode, zoom):
+    mo.hstack([c_re, c_im, zoom, view_mode], justify="start")
     return
 
 
 @app.cell
-def _():
-    return
-
-
-@app.cell
-def _():
+def _(mo, res_img, src_img):
+    mo.hstack([src_img, res_img], justify="start")
     return
 
 

--- a/sliders.py
+++ b/sliders.py
@@ -19,150 +19,128 @@ app = marimo.App(width="columns", sql_output="polars")
 @app.cell
 def _():
     import marimo as mo
-    from wigglystuff import Paint
+    import numpy as np
+    import io
+    from PIL import Image, ImageDraw
+    from scipy.ndimage import map_coordinates
 
-    return Paint, mo
+    return Image, ImageDraw, io, map_coordinates, mo, np
+
+
+@app.cell
+def _(Image, ImageDraw, io):
+    def get_source_image(file_list):
+        # Check if a file was actually uploaded
+        if file_list:
+            try:
+                # upload.value is a list of marimo.ui.file.File objects
+                # .contents contains the raw bytes
+                return Image.open(io.BytesIO(file_list[0].contents)).convert("RGB")
+            except Exception as e:
+                return None
+
+        # Fallback Placeholder: A "Frame" to make alignment obvious
+        img = Image.new("RGB", (600, 600), "#fdfcf0")
+        draw = ImageDraw.Draw(img)
+        # Outer black border
+        draw.rectangle([0, 0, 599, 599], outline="black", width=30)
+        # Inner red border (The "Target" for the loop)
+        draw.rectangle([200, 200, 400, 400], outline="#e74c3c", width=15)
+        draw.text((260, 40), "OUTER", fill="black")
+        draw.text((265, 220), "INNER", fill="#e74c3c")
+        return img
+
+    return (get_source_image,)
 
 
 @app.cell
 def _(mo):
-    import numpy as np
-    from PIL import Image, ImageDraw
-    from scipy.ndimage import map_coordinates
-
-    upload = mo.ui.file(kind="button", label="Upload Image", filetypes=[".png"])
-    c_re = mo.ui.slider(0.1, 2.0, step=0.01, value=1.0, label="Scale ($c_{re}$)")
-    c_im = mo.ui.slider(-1.0, 1.0, step=0.01, value=0.0, label="Twist ($c_{im}$)")
-    zoom = mo.ui.slider(0.0, 10.0, step=0.01, value=0.0, label="Zoom Depth")
-    view_mode = mo.ui.radio(["Spiral Space", "Log Space"], value="Spiral Space")
-
-    mo.md(
-        f"""
-        # 3Blue1Brown Droste Mapping
-        Adjust the sliders to "align" the tiles.
-
-        {mo.vstack([upload, view_mode] + [c_re, c_im, zoom], justify="space-around")}
-        """
-    )
-    return (
-        Image,
-        ImageDraw,
-        c_im,
-        c_re,
-        map_coordinates,
-        np,
-        upload,
-        view_mode,
-        zoom,
-    )
+    upload = mo.ui.file(kind="button", label="Upload Screenshot")
+    c_re = mo.ui.slider(0.1, 4.0, step=0.01, value=1.0, label="Scale ($c_{re}$)")
+    c_im = mo.ui.slider(-2.0, 2.0, step=0.01, value=0.0, label="Twist ($c_{im}$)")
+    zoom = mo.ui.slider(0.0, 1.0, step=0.01, value=0.0, label="Zoom Depth")
+    view_mode = mo.ui.radio(["Spiral Space", "Log Space"], value="Spiral Space", label="View")
+    return c_im, c_re, upload, view_mode, zoom
 
 
 @app.cell
-def _(get_source, upload):
-    get_source(upload.value)
-    return
-
-
-@app.cell
-def _(Paint, get_source, mo, upload):
-    _src = get_source(upload.value)
-    widget = mo.ui.anywidget(Paint(init_image=_src))
-    widget
-    return (widget,)
-
-
-@app.cell
-def _(Image, ImageDraw, mo, upload):
-    import io 
-
+def _(Image, map_coordinates, mo, np):
     @mo.cache
-    def get_source(file_val):
-        if file_val:
-            raw_data = upload.value[0].contents
-
-            # Use io.BytesIO to make it "look" like a file for PIL
-            img = Image.open(io.BytesIO(raw_data)).convert("RGB")
-            # Resize to a manageable size for real-time slider performance
-            img.thumbnail((600, 600))
-            return img
-
-        # Procedural placeholder with alignment markers
-        img = Image.new("RGB", (300, 300), (245, 245, 240))
-        d = ImageDraw.Draw(img)
-        d.rectangle([0, 0, 299, 299], outline="black", width=10) # Outer
-        d.rectangle([100, 100, 200, 200], outline="red", width=5) # Inner
-        d.text((120, 10), "OUTER", fill="black")
-        return img
-
-    return (get_source,)
-
-
-@app.cell
-def _(np, widget):
-    # Prepare the image and its metadata once
-    img_array = np.array(widget.get_pil())
-    h, w, _ = img_array.shape
-    return
-
-
-@app.cell
-def _(
-    Image,
-    c_im,
-    c_re,
-    get_source,
-    map_coordinates,
-    mo,
-    np,
-    upload,
-    view_mode,
-    zoom,
-):
-    @mo.cache
-    def compute_droste(img, cr, ci, z_depth, mode):
+    def apply_droste(img, cr, ci, z_shift, mode):
+        # Convert image to numpy array for math
         arr = np.array(img)
         h, w, _ = arr.shape
 
-        # Grid in [-1, 1]
+        # Generate pixel grid in normalized coordinates [-1, 1]
         y, x = np.indices((h, w))
-        u, v = (x - w/2) / (w/2), (y - h/2) / (h/2)
+        u, v = (x - w / 2) / (w / 2), (y - h / 2) / (h / 2)
 
-        # 1. Log-Polar Coordinates
-        # We add z_depth to the radius to "travel" through the spiral
-        r_log = 0.5 * np.log(u**2 + v**2 + 1e-9) + (z_depth * 2)
+        # 1. Map to Log-Polar Space (The Top-Middle Image in the video)
+        # r_log is ln(radius), theta is the angle
+        r_log = 0.5 * np.log(u**2 + v**2 + 1e-9)
         theta = np.arctan2(v, u)
 
-        # 2. Apply the Complex Linear Map: f(z) = c * z
-        # This is the "Bizarre Log Space" transformation
+        # Add the Zoom Shift (traveling through the log-radius)
+        r_log += z_shift * 2.0
+
+        # 2. Apply Linear Transformation: f(z) = c * z
+        # This creates the spiral/scaling effect
         z_real = cr * r_log - ci * theta
         z_imag = ci * r_log + cr * theta
 
         if mode == "Log Space":
-            # Visualize the tiled grid
+            # Visualize the repeating grid
             map_x = (z_real * (w / 4)) % w
             map_y = (z_imag / (2 * np.pi) * h) % h
         else:
-            # 3. Back to Cartesian with Periodic tiling
-            # The modulo on the log-radius creates the infinite nesting
-            r_final = np.exp(z_real % 1.0) 
+            # 3. Map back to Cartesian with Periodic Tiling
+            # Modulo on log-radius creates the infinite nesting
+            # We use % 1.0 to snap back to the outer frame once we hit the inner
+            r_final = np.exp(z_real % 1.0)
             theta_final = z_imag
 
             map_x = (r_final * np.cos(theta_final) + 1) / 2 * w
             map_y = (r_final * np.sin(theta_final) + 1) / 2 * h
 
-        # 4. Sampling with boundary handling
-        out = np.stack([
-            map_coordinates(arr[..., i], [map_y % h, map_x % w], order=1) 
-            for i in range(3)
-        ], axis=-1)
+        # 4. Resample pixels using interpolation for all 3 RGB channels
+        output_channels = []
+        for i in range(3):
+            ch = map_coordinates(arr[..., i], [map_y % h, map_x % w], order=1)
+            output_channels.append(ch)
 
-        return Image.fromarray(out)
+        return Image.fromarray(np.stack(output_channels, axis=-1))
 
-    # --- 4. RENDER LOOP ---
-    src = get_source(upload.value)
-    dst = compute_droste(src, c_re.value, c_im.value, zoom.value, view_mode.value)
+    return (apply_droste,)
 
-    mo.hstack([src, dst], justify="space-around")
+
+@app.cell
+def _(apply_droste, c_im, c_re, get_source_image, mo, upload, view_mode, zoom):
+    src_img = get_source_image(upload.value)
+    res_img = apply_droste(src_img, c_re.value, c_im.value, zoom.value, view_mode.value)
+
+    mo.md(
+        f"""
+        # 3Blue1Brown Droste Simulator
+        {mo.hstack([upload, view_mode], justify="space-between")}
+    
+        ### Controls
+        {mo.hstack([c_re, c_im, zoom], justify="start")}
+    
+        ---
+        ### Transformation Result
+        {mo.hstack([src_img, res_img], justify="space-around")}
+        """
+    )
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+@app.cell
+def _():
     return
 
 


### PR DESCRIPTION
## Summary
- Adds `conformal-mapping.py`: an interactive marimo notebook exploring complex-plane conformal mappings with checkerboard/UV textures and a draggable puck widget
- Adds `sliders.py`: a Droste effect notebook with sliders for scale, twist, and zoom depth, supporting image upload and log-space visualization

## Test plan
- [ ] Run `marimo edit conformal-mapping.py` and verify checkerboard/UV plots and puck interaction
- [ ] Run `marimo edit sliders.py` and verify Droste effect renders with slider changes and image upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)