### PR TITLE
Add SSoT PIF bias notebook

### DIFF
--- a/.agents/skills/implement-paper/SKILL.md
+++ b/.agents/skills/implement-paper/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement-paper
-description: Implement a research paper as an interactive marimo notebook. Starts by understanding what the user wants to explore, fetches the paper via alphaxiv, then builds a focused notebook.
+description: Implement a research paper as an interactive marimo notebook together with the user. Start by understanding what the user wants to explore, fetch the paper via alphaxiv, then build a focused notebook.
 ---
 
 # Implement Paper
@@ -20,6 +20,8 @@ Before fetching or reading anything, have a short conversation to scope the work
 Only move on once you have a clear picture of what to build.
 
 ## Step 2: Fetch the paper
+
+If the user gives you an Arxiv/AlphaXiv link, you will an efficient way to read the paper. 
 
 See [references/fetching-papers.md](references/fetching-papers.md) for how to retrieve paper content via alphaxiv.org. This avoids reading raw PDFs and gives you structured markdown.
 
@@ -59,3 +61,5 @@ Key guidelines:
 - **Don't reproduce the entire paper.** Focus on what the user asked about in Step 1.
 - **Iterate visually.** Build up figures incrementally (e.g., show data → show model fit → show residuals) rather than dumping everything into one plot.
 - **If the paper uses heavy notation**, include a small "notation reference" cell with a markdown table mapping symbols to descriptions.
+
+If the user wants a custom anywidget, refer to [references/ANYWIDGET.md](references/ANYWIDGET.md).

--- a/.agents/skills/implement-paper/references/anywidget.md
+++ b/.agents/skills/implement-paper/references/anywidget.md
@@ -74,6 +74,8 @@ Unless specifically told otherwise, assume the following:
    - Show basic usage only
    - Don't combine with other marimo UI elements unless explicitly requested
 
+5. **External file paths**: When using pathlib for external `_esm`/`_css` files, keep paths relative to the project directory, consider using `Path(__file__)` for this. Do not read files outside the project (e.g., `~/.ssh`, `~/.env`, `/etc/`) or embed their contents in widget output.
+
 Dumber is better. Prefer obvious, direct code over clever abstractions—someone
 new to the project should be able to read the code top-to-bottom and grok it
 without needing to look up framework magic or trace through indirection.

--- a/.agents/skills/marimo-batch/SKILL.md
+++ b/.agents/skills/marimo-batch/SKILL.md
@@ -95,3 +95,14 @@ def _(mo):
     mo.md(r"""demo""")
 ```
 
+## Compute platform 
+
+When the job is ready to get some serious compute, it is important that we keep good practices in mind. Consider batch sizes for the data set and make sure that there are plenty of logs so the user can spot if issues arise. 
+
+## Grid search
+
+When the user wants to run a hyperparameter sweep, point them to [this grid launcher](references/grid.py). It works with the notebook in `references/starting-point.py` out of the box: it samples random combinations from a search space that matches the notebook's `ModelParams` fields and launches each one as a separate job.
+
+By default the script does a dry run (`uv run grid.py`) so the user can inspect the combinations before spending compute. Pass `--launch` to actually submit jobs. The `--count` and `--seed` flags control how many combinations to sample and the RNG seed.
+
+The reference uses Hugging Face Jobs as the compute provider, but this is just one option. The user can swap it out for Modal, RunPod, or any other provider that can run a uv script.

--- a/.agents/skills/marimo-batch/references/grid.py
+++ b/.agents/skills/marimo-batch/references/grid.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# /// script
+# dependencies = [
+#     "huggingface-hub>=0.34",
+#     "numpy",
+#     "python-dotenv",
+# ]
+# ///
+"""
+Randomized hyperparameter grid launcher for starting-point.py.
+
+This script samples random hyperparameter combinations and launches
+each one as a separate job. By default it does a dry run so you can
+inspect the combinations before committing to actual compute.
+
+Usage:
+    uv run grid.py                 # dry run, prints 12 combos
+    uv run grid.py --count 20      # dry run, prints 20 combos
+    uv run grid.py --launch        # actually submit jobs
+
+Note on compute providers:
+    This reference uses Hugging Face Jobs (via `huggingface_hub.run_uv_job`)
+    as the compute backend, but this is just one option. You could swap it
+    out for Modal, RunPod, or any other provider that can run a uv script.
+    We use HF Jobs here because it provides a nice self-contained example.
+"""
+
+import argparse
+import os
+import random
+import shlex
+from pathlib import Path
+
+import numpy as np
+from dotenv import load_dotenv
+
+# Hugging Face Jobs is just one compute provider — see the note in the
+# module docstring above. Replace this with your provider of choice.
+from huggingface_hub import run_uv_job
+
+
+PROJECT_DIR = Path(__file__).resolve().parent
+NOTEBOOK_PATH = PROJECT_DIR / "starting-point.py"
+
+FLAVOR = "a100-large"
+TIMEOUT = "6h"
+JOB_ENV = {
+    "PYTHONUNBUFFERED": "1",
+    "PYTORCH_ALLOC_CONF": "expandable_segments:True",
+}
+
+# The search space keys must match the ModelParams fields in starting-point.py.
+# Adjust the ranges and values to suit your experiment.
+SEARCH_SPACE = {
+    "epochs": [10, 15, 20, 25, 30, 40, 50],
+    "batch_size": [8, 16, 32, 64, 128, 256, 512],
+    "learning_rate": np.logspace(np.log10(1e-5), np.log10(5e-4), num=10).tolist(),
+}
+
+FIXED = {
+    "wandb_project": "batch-sizes",
+}
+
+
+def normalize_value(value: object) -> object:
+    if isinstance(value, np.integer):
+        return int(value)
+    if isinstance(value, np.floating):
+        return float(value)
+    return value
+
+
+def format_value(value: object) -> str:
+    value = normalize_value(value)
+    if isinstance(value, float):
+        return f"{value:.6g}"
+    return str(value)
+
+
+def build_run_name(params: dict[str, str]) -> str:
+    return (
+        f"e{params['epochs']}"
+        f"-bs{params['batch_size']}"
+        f"-lr{params['learning_rate']}"
+    )
+
+
+def sample_runs(count: int, rng: random.Random) -> list[dict[str, str]]:
+    keys = list(SEARCH_SPACE.keys())
+    seen: set[tuple[str, ...]] = set()
+    runs: list[dict[str, str]] = []
+
+    max_unique = 1
+    for values in SEARCH_SPACE.values():
+        max_unique *= len(values)
+
+    target = min(count, max_unique)
+    while len(runs) < target:
+        params = {key: normalize_value(rng.choice(SEARCH_SPACE[key])) for key in keys}
+        signature = tuple(format_value(params[key]) for key in keys)
+        if signature in seen:
+            continue
+        seen.add(signature)
+
+        run = {key: format_value(value) for key, value in params.items()}
+        run.update(FIXED)
+        run["wandb_run_name"] = build_run_name(run)
+        runs.append(run)
+
+    return runs
+
+
+def params_to_cli_args(params: dict[str, str]) -> list[str]:
+    args: list[str] = []
+    for key, value in params.items():
+        args.extend([f"--{key.replace('_', '-')}", str(value)])
+    return args
+
+
+def print_run(index: int, total: int, params: dict[str, str]) -> None:
+    cli_args = params_to_cli_args(params)
+    print(f"[{index}/{total}] {params['wandb_run_name']}")
+    print(f"  flavor: {FLAVOR}")
+    print(f"  timeout: {TIMEOUT}")
+    print(f"  args: {' '.join(shlex.quote(arg) for arg in cli_args)}")
+
+
+def load_secrets() -> dict[str, str]:
+    load_dotenv(PROJECT_DIR / ".env")
+    secrets: dict[str, str] = {}
+    for key in ("HF_TOKEN", "WANDB_API_KEY"):
+        value = os.environ.get(key)
+        if not value:
+            raise SystemExit(f"Missing required secret: {key}")
+        secrets[key] = value
+    return secrets
+
+
+# This function uses huggingface_hub.run_uv_job to launch jobs.
+# Swap this out if you use a different compute provider.
+def launch_run(index: int, total: int, params: dict[str, str], secrets: dict[str, str]) -> None:
+    print_run(index, total, params)
+    job = run_uv_job(
+        str(NOTEBOOK_PATH),
+        script_args=params_to_cli_args(params),
+        flavor=FLAVOR,
+        timeout=TIMEOUT,
+        env=JOB_ENV,
+        secrets=secrets,
+    )
+    print(f"  launched: {job.url}")
+    print()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Launch randomized hyperparameter sweeps for starting-point.py"
+    )
+    parser.add_argument(
+        "--count",
+        type=int,
+        default=12,
+        help="Number of randomized parameter combinations to sample.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="RNG seed used to sample combinations.",
+    )
+    parser.add_argument(
+        "--launch",
+        action="store_true",
+        help="Actually submit the sampled runs. Without this flag, only a dry run is printed.",
+    )
+    args = parser.parse_args()
+
+    if args.count <= 0:
+        raise SystemExit("--count must be positive")
+
+    rng = random.Random(args.seed)
+    runs = sample_runs(args.count, rng)
+    secrets = load_secrets() if args.launch else None
+
+    print(
+        f"Randomized grid search with {len(runs)} runs "
+        f"(requested={args.count}, seed={args.seed})"
+    )
+    print(f"Notebook: {NOTEBOOK_PATH.name}")
+    print(f"Flavor: {FLAVOR}")
+    print(f"Timeout: {TIMEOUT}")
+    print(f"Fixed params: {FIXED}")
+    print(f"Job env: {JOB_ENV}")
+    print()
+
+    for index, params in enumerate(runs, start=1):
+        if args.launch:
+            launch_run(index, len(runs), params, secrets)
+        else:
+            print_run(index, len(runs), params)
+            print("  (dry run)")
+            print()
+
+    if not args.launch:
+        print("Dry run complete. Pass --launch to submit jobs.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/marimo-batch/references/starting-point.py
+++ b/.agents/skills/marimo-batch/references/starting-point.py
@@ -5,26 +5,19 @@
 #     "python-dotenv==1.2.1",
 #     "rich==14.3.2",
 #     "wigglystuff==0.2.30",
+#     "torch==2.11.0",
+#     "wandb==0.25.1",
 # ]
 # requires-python = ">=3.14"
 # ///
 
 import marimo
 
-__generated_with = "0.19.11"
+__generated_with = "0.21.1"
 app = marimo.App(width="columns")
 
 
-@app.cell(column=0)
-def _():
-    import marimo as mo
-    from dotenv import load_dotenv
-
-    load_dotenv(".env")
-    return (mo,)
-
-
-@app.cell(hide_code=True)
+@app.cell(column=0, hide_code=True)
 def _(mo):
     mo.md(r"""
     ## Notebook Description
@@ -41,8 +34,17 @@ def _(mo):
 
 
 @app.cell
-def _(env_config, is_script_mode):
-    env_config if not is_script_mode else None
+def _():
+    import marimo as mo
+    from dotenv import load_dotenv
+
+    load_dotenv(".env")
+    return (mo,)
+
+
+@app.cell
+def _(env_config, is_script_mode, wandb):
+    env_config if not is_script_mode and not wandb.login() else None
     return
 
 
@@ -53,9 +55,13 @@ def _(ModelParams, mo, wandb):
 
     is_script_mode = mo.app_meta().mode == "script"
 
-    env_config = mo.ui.anywidget(EnvConfig({
-        "WANDB_API_KEY": lambda k: wandb.login(key=k, verify=True),
-    }))
+    env_config = mo.ui.anywidget(
+        EnvConfig(
+            {
+                "WANDB_API_KEY": lambda k: wandb.login(key=k, verify=True),
+            }
+        )
+    )
 
     if is_script_mode and not mo.cli_args():
         from rich.console import Console
@@ -69,7 +75,11 @@ def _(ModelParams, mo, wandb):
 
         for name, field in ModelParams.model_fields.items():
             flag = f"--{name.replace('_', '-')}"
-            type_name = field.annotation.__name__ if hasattr(field.annotation, "__name__") else str(field.annotation)
+            type_name = (
+                field.annotation.__name__
+                if hasattr(field.annotation, "__name__")
+                else str(field.annotation)
+            )
             table.add_row(flag, type_name, str(field.default), field.description or "")
 
         Console().print(table)
@@ -79,7 +89,9 @@ def _(ModelParams, mo, wandb):
 
 @app.cell
 def _():
-    return
+    import wandb
+
+    return (wandb,)
 
 
 @app.cell(column=1, hide_code=True)
@@ -102,17 +114,19 @@ def _():
     import json
     from pydantic import computed_field, BaseModel, Field
 
+
     class ModelParams(BaseModel):
         epochs: int = Field(default=25, description="Number of training epochs.")
         batch_size: int = Field(default=32, description="Training batch size.")
         learning_rate: float = Field(default=1e-4, description="Learning rate for AdamW.")
-        wandb_project: str = Field(default="batch-sizes", description="W&B project name (empty to skip).")
+        wandb_project: str = Field(
+            default="batch-sizes", description="W&B project name (empty to skip)."
+        )
 
         @computed_field
         @property
         def run_name(self) -> str:
             parts = [
-                self.loss_name,
                 f"e{self.epochs}",
                 f"bs{self.batch_size}",
                 f"lr{self.learning_rate:.0e}",
@@ -130,34 +144,44 @@ def _():
 
 @app.cell
 def _(mo):
-    params_form = mo.md("""
+    params_form = (
+        mo.md("""
     ## Model parameters
 
     {epochs}
     {batch_size}
     {learning_rate}
-    """).batch(
-        epochs=mo.ui.slider(10, 50, value=50, step=1, label="epochs"),
-        batch_size=mo.ui.slider(8, 512, value=32, step=8, label="batch size"),
-        learning_rate=mo.ui.slider(1e-5, 5e-4, value=1e-4, step=1e-5, label="learning rate"),
-    ).form()
+    """)
+        .batch(
+            epochs=mo.ui.slider(10, 50, value=50, step=1, label="epochs"),
+            batch_size=mo.ui.slider(8, 512, value=32, step=8, label="batch size"),
+            learning_rate=mo.ui.slider(1e-5, 5e-4, value=1e-4, step=1e-5, label="learning rate"),
+        )
+        .form()
+    )
     return (params_form,)
 
 
 @app.cell
 def _(ModelParams, is_script_mode, mo, params_form):
+    mo.stop(
+        not is_script_mode and params_form.value is None,
+        mo.md("*Submit the form to start training.*"),
+    )
+
     if is_script_mode:
-        model_params = ModelParams(
-            **{k.replace("-", "_"): v for k, v in mo.cli_args().items()}
-        )
+        model_params = ModelParams(**{k.replace("-", "_"): v for k, v in mo.cli_args().items()})
     else:
-        model_params = ModelParams(**(params_form.value or {}))
-    return
+        model_params = ModelParams(**params_form.value)
+    return (model_params,)
 
 
 @app.cell
 def _():
-    return
+    import torch
+    import torch.nn as nn
+
+    return nn, torch
 
 
 @app.cell(column=2, hide_code=True)
@@ -169,8 +193,16 @@ def _(mo):
 
 
 @app.cell
-def _():
-    return
+def _(model_params, torch):
+    X = torch.randn(1000, 10)
+    w_true = torch.randn(10, 1)
+    y = X @ w_true + 0.1 * torch.randn(1000, 1)
+
+    dataset = torch.utils.data.TensorDataset(X, y)
+    train_loader = torch.utils.data.DataLoader(
+        dataset, batch_size=model_params.batch_size, shuffle=True
+    )
+    return (train_loader,)
 
 
 @app.cell(column=3, hide_code=True)
@@ -182,8 +214,15 @@ def _(mo):
 
 
 @app.cell
-def _():
-    return
+def _(nn):
+    model = nn.Sequential(
+        nn.Linear(10, 32),
+        nn.ReLU(),
+        nn.Linear(32, 1),
+    )
+
+    model
+    return (model,)
 
 
 @app.cell(column=4, hide_code=True)
@@ -195,7 +234,36 @@ def _(mo):
 
 
 @app.cell
-def _():
+def _(mo, model, model_params, nn, torch, train_loader, wandb):
+    if model_params.wandb_project:
+        wandb.init(
+            project=model_params.wandb_project,
+            name=model_params.run_name,
+            config=model_params.model_dump(),
+        )
+
+    optimizer = torch.optim.AdamW(model.parameters(), lr=model_params.learning_rate)
+    loss_fn = nn.MSELoss()
+
+    with mo.status.progress_bar(total=model_params.epochs) as bar:
+        for epoch in range(model_params.epochs):
+            epoch_loss = 0.0
+            for xb, yb in train_loader:
+                pred = model(xb)
+                loss = loss_fn(pred, yb)
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
+                epoch_loss += loss.item()
+            avg_loss = epoch_loss / len(train_loader)
+            if model_params.wandb_project:
+                wandb.log({"epoch": epoch, "loss": avg_loss})
+            bar.update()
+
+    if model_params.wandb_project:
+        wandb.finish()
+
+    mo.md(f"**Training complete.** Final loss: `{avg_loss:.6f}`")
     return
 
 

--- a/.agents/skills/marimo-notebook/SKILL.md
+++ b/.agents/skills/marimo-notebook/SKILL.md
@@ -216,18 +216,6 @@ def _(mo, condition):
     return
 ```
 
-## Marimo Variable Naming
-
-Variables in `for` loops that would conflict across cells need underscore prefix:
-
-```python
-# Use _name, _model to make them cell-private
-for _name, _model in items:
-    ...
-```
-
-You have a tendency to overdo `_prefix` variables. **Hard rule: never underscore-prefix imports.** Only use `_prefix` for loop variables or temporaries that would genuinely collide with another cell's named outputs. Overdoing underscores (e.g. `import re as _re`, `_result = ...`) makes code deeply unpythonic and harder to read for zero benefit. It's better to start without these _prefix variables and to only correct them once the `uvx marimo check` linter fails. 
-
 ## PEP 723 Dependencies
 
 Notebooks created via `marimo edit --sandbox` have these dependencies added to the top of the file automatically but it is a good practice to make sure these exist when creating a notebook too: 
@@ -250,7 +238,9 @@ When working on a notebook it is important to check if the notebook can run. Tha
 uvx marimo check <notebook.py>
 ```
 
-Make sure these are checked before handing a notebook back to the user.
+Make sure these are checked before handing a notebook back to the user. 
+
+**Important**: you have a tendency to over-do variables with an underscore prefix. You should only apply this to one or two variables at most. Consider creating a new variable instead of prefixing entire cells in marimo. 
 
 ## api docs
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -9,17 +9,17 @@
     "implement-paper": {
       "source": "marimo-team/skills",
       "sourceType": "github",
-      "computedHash": "f08d521800f34c952012f306e5429bb1e87527432566273083ea9f1bc96897e7"
+      "computedHash": "aa30bbcc39bf51a5f6abea45ce537d21bfa018c875f4378707666c572d891d73"
     },
     "marimo-batch": {
       "source": "marimo-team/skills",
       "sourceType": "github",
-      "computedHash": "b697e72139093c633f2b34b56e0b02c69c5ebff53e4ebdd3c0fbe033a2af5f84"
+      "computedHash": "8af0436514aac6a0317733cb0897adc08026a22e82c5beb1ed92eb4bba7e5f4f"
     },
     "marimo-notebook": {
       "source": "marimo-team/skills",
       "sourceType": "github",
-      "computedHash": "48a44d4a8cf223adabad6b28d12134eb8751f4ef4d867474d2f1737c8bf920a4"
+      "computedHash": "4271f43564b3b8bb41cba36ae4b9ada0164430cc3a1f81267bd5f8cc2d602a9e"
     },
     "marimo-pair": {
       "source": "marimo-team/marimo-pair",

--- a/ssot-pif-bias.py
+++ b/ssot-pif-bias.py
@@ -1,0 +1,438 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "marimo",
+#     "transformers",
+#     "torch",
+#     "accelerate",
+#     "numpy",
+#     "pandas",
+#     "altair",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.23.2"
+app = marimo.App(width="medium")
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    # LLMs can't pick at random
+
+    Partial reproduction of **[String Seed of Thought (ICLR 2026)](https://arxiv.org/abs/2510.21150)**.
+
+    The paper argues that LLMs fail at **Probabilistic Instruction Following (PIF)**:
+    when asked to sample from a target distribution (e.g. *"pick a digit 1–10 uniformly"*),
+    outputs collapse onto a few favourites rather than matching the target.
+
+    This notebook checks whether the bias shows up in a small local Qwen model
+    by asking it the same uniform-random question many times and counting.
+    It then re-runs each task with the paper's **String Seed of Thought** prompt
+    (ask for a random string first, derive the answer from it) and compares.
+    """)
+    return
+
+
+@app.cell
+def _():
+    import marimo as mo
+    import re
+
+    import altair as alt
+    import numpy as np
+    import pandas as pd
+    import torch
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    return AutoModelForCausalLM, AutoTokenizer, alt, mo, np, pd, re, torch
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Setup
+    """)
+    return
+
+
+@app.cell
+def _():
+    MODEL_REGISTRY = {
+        "Qwen2.5-0.5B-Instruct": "Qwen/Qwen2.5-0.5B-Instruct",
+        "Qwen2.5-1.5B-Instruct": "Qwen/Qwen2.5-1.5B-Instruct",
+        "Qwen2.5-3B-Instruct": "Qwen/Qwen2.5-3B-Instruct",
+    }
+    return (MODEL_REGISTRY,)
+
+
+@app.cell
+def _(MODEL_REGISTRY, mo):
+    model_dropdown = mo.ui.dropdown(
+        options=list(MODEL_REGISTRY.keys()),
+        value="Qwen2.5-0.5B-Instruct",
+        label="Qwen model",
+    )
+    n_samples_slider = mo.ui.slider(
+        start=20,
+        stop=500,
+        step=20,
+        value=100,
+        label="samples per task",
+        show_value=True,
+    )
+    mo.vstack([model_dropdown, n_samples_slider])
+    return model_dropdown, n_samples_slider
+
+
+@app.cell
+def _(torch):
+    if torch.cuda.is_available():
+        device = "cuda"
+        dtype = torch.bfloat16
+    elif torch.backends.mps.is_available():
+        device = "mps"
+        dtype = torch.bfloat16
+    else:
+        device = "cpu"
+        dtype = torch.float32
+    return device, dtype
+
+
+@app.cell(hide_code=True)
+def _(
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    MODEL_REGISTRY,
+    device,
+    dtype,
+    model_dropdown,
+):
+    repo_id = MODEL_REGISTRY[model_dropdown.value]
+    tokenizer = AutoTokenizer.from_pretrained(repo_id)
+    tokenizer.padding_side = "left"
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    model = AutoModelForCausalLM.from_pretrained(
+        repo_id,
+        dtype=dtype,
+        device_map={"": device},
+    )
+    model.eval()
+    return model, tokenizer
+
+
+@app.cell
+def _():
+    TASKS = {
+        "digit 1–10": {
+            "prompt": "Pick a digit from 1 to 10 uniformly at random. Reply with only the digit.",
+            "options": [str(i) for i in range(1, 11)],
+            "kind": "digit",
+        },
+        "letter A–E": {
+            "prompt": "Pick a letter from A, B, C, D, or E uniformly at random. Reply with only the letter.",
+            "options": list("ABCDE"),
+            "kind": "letter",
+        },
+        "coin flip": {
+            "prompt": "Flip a fair coin. Reply with only the word 'heads' or 'tails'.",
+            "options": ["heads", "tails"],
+            "kind": "word",
+        },
+        "flip coin": {
+            "prompt": "Flip a fair coin. Reply with only the word 'tails' or 'heads'.",
+            "options": ["tails", "heads"],
+            "kind": "word",
+        },
+    }
+    return (TASKS,)
+
+
+@app.cell
+def _(re):
+    KIND_REGEX = {
+        "digit": re.compile(r"\b(10|[1-9])\b"),
+        "letter": re.compile(r"\b([A-Ea-e])\b"),
+        "word": re.compile(r"\b(heads|tails)\b", re.IGNORECASE),
+    }
+    ANSWER_RX = re.compile(r"answer\s*[:\-]\s*(.*)", re.IGNORECASE | re.DOTALL)
+    TRAIL_STRIP = re.compile(r"[\s.,!?;:\"'`*()\[\]{}]+$")
+
+    def ssot_wrap(prompt):
+        return (
+            "First, generate a random 12-character string of lowercase letters "
+            "as an entropy source. Then, based on that string, answer this: "
+            f"{prompt} End your reply with 'Answer: <choice>' on the last line."
+        )
+
+    def _normalize(kind, raw_value):
+        if kind == "letter":
+            return raw_value.upper()
+        if kind == "word":
+            return raw_value.lower()
+        return raw_value
+
+    def parse_regex(raw, task):
+        answer = ANSWER_RX.search(raw)
+        search_in = answer.group(1) if answer else raw
+        m = KIND_REGEX[task["kind"]].search(search_in)
+        return _normalize(task["kind"], m.group(1)) if m else None
+
+    def parse_tail(raw, task):
+        text = TRAIL_STRIP.sub("", raw.strip())
+        if not text:
+            return None
+        kind = task["kind"]
+        options = task["options"]
+        if kind == "digit":
+            m = re.search(r"(10|[1-9])\s*$", text)
+            return m.group(1) if m else None
+        if kind == "letter":
+            last = text[-1].upper()
+            return last if last in options else None
+        last_word = text.split()[-1].strip(".,!?;:\"'`*()[]{}").lower()
+        return last_word if last_word in options else None
+
+    return parse_regex, parse_tail, ssot_wrap
+
+
+@app.cell
+def _(torch):
+    def sample_task(prompt, n, model, tokenizer, device, max_new_tokens=8):
+        messages = [{"role": "user", "content": prompt}]
+        formatted = tokenizer.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True
+        )
+        inputs = tokenizer(formatted, return_tensors="pt").to(device)
+        input_ids = inputs.input_ids.repeat(n, 1)
+        attention_mask = inputs.attention_mask.repeat(n, 1)
+        with torch.no_grad():
+            outputs = model.generate(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                do_sample=True,
+                temperature=1.0,
+                max_new_tokens=max_new_tokens,
+                pad_token_id=tokenizer.pad_token_id,
+            )
+        generated = outputs[:, input_ids.shape[1]:]
+        return tokenizer.batch_decode(generated, skip_special_tokens=True)
+
+    return (sample_task,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Sampling
+    """)
+    return
+
+
+@app.cell
+def _(
+    TASKS,
+    device,
+    mo,
+    model,
+    n_samples_slider,
+    parse_regex,
+    parse_tail,
+    pd,
+    sample_task,
+    ssot_wrap,
+    tokenizer,
+):
+    def run_tasks(tasks, n):
+        rows = []
+        for name, task in tasks.items():
+            baseline = sample_task(
+                task["prompt"], n, model, tokenizer, device, max_new_tokens=8
+            )
+            for raw in baseline:
+                rows.append({
+                    "task": name,
+                    "mode": "baseline",
+                    "raw": raw.strip(),
+                    "parsed": parse_regex(raw, task),
+                })
+            ssot = sample_task(
+                ssot_wrap(task["prompt"]),
+                n,
+                model,
+                tokenizer,
+                device,
+                max_new_tokens=80,
+            )
+            for raw in ssot:
+                rows.append({
+                    "task": name,
+                    "mode": "SSoT (regex)",
+                    "raw": raw.strip(),
+                    "parsed": parse_regex(raw, task),
+                })
+                rows.append({
+                    "task": name,
+                    "mode": "SSoT (tail)",
+                    "raw": raw.strip(),
+                    "parsed": parse_tail(raw, task),
+                })
+        return pd.DataFrame(rows)
+
+    results = run_tasks(TASKS, n_samples_slider.value)
+
+
+    mo.accordion({"show model results": results})
+    return (results,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Results
+    """)
+    return
+
+
+@app.cell
+def _(TASKS, pd, results):
+    MODES = ["baseline", "SSoT (regex)", "SSoT (tail)"]
+
+    def compute_empirical(df, tasks):
+        rows = []
+        for name, task in tasks.items():
+            target_pct = 100 / len(task["options"])
+            for mode in MODES:
+                parsed = df[
+                    (df["task"] == name) & (df["mode"] == mode)
+                ]["parsed"].dropna()
+                total = len(parsed)
+                for opt in task["options"]:
+                    count = int((parsed == opt).sum())
+                    rows.append({
+                        "task": name,
+                        "mode": mode,
+                        "option": opt,
+                        "count": count,
+                        "pct": 100 * count / total if total else 0.0,
+                        "target_pct": target_pct,
+                    })
+        return pd.DataFrame(rows)
+
+    empirical = compute_empirical(results, TASKS)
+    return MODES, empirical
+
+
+@app.cell(hide_code=True)
+def _(MODES, TASKS, alt, empirical):
+    _colors = ["#8c8c8c", "#4c78a8", "#f58518"]
+    _color_scale = alt.Scale(domain=MODES, range=_colors)
+
+    def _task_chart(task_name):
+        sub = empirical[empirical["task"] == task_name]
+        bars = alt.Chart(sub).mark_bar().encode(
+            x=alt.X(
+                "option:N",
+                sort=None,
+                title=None,
+                axis=alt.Axis(labelAngle=0),
+                scale=alt.Scale(paddingInner=0.2, paddingOuter=0.1),
+            ),
+            xOffset=alt.XOffset(
+                "mode:N", sort=MODES, scale=alt.Scale(paddingInner=0.0)
+            ),
+            y=alt.Y("pct:Q", title="% of parsed samples"),
+            color=alt.Color(
+                "mode:N",
+                sort=MODES,
+                scale=_color_scale,
+                legend=alt.Legend(title=None, orient="top"),
+            ),
+            tooltip=[
+                "mode",
+                "option",
+                "count",
+                alt.Tooltip("pct:Q", format=".1f"),
+                alt.Tooltip("target_pct:Q", format=".1f"),
+            ],
+        )
+        rule = alt.Chart(sub).mark_rule(
+            color="crimson", strokeDash=[4, 4]
+        ).encode(y="target_pct:Q")
+        return (bars + rule).properties(
+            title=task_name, width=560, height=180
+        )
+
+    chart = alt.vconcat(*[_task_chart(t) for t in TASKS]).resolve_scale(
+        color="shared"
+    )
+    chart
+    return
+
+
+@app.cell
+def _(MODES, TASKS, np, pd, results):
+    def compute_entropy(df, tasks):
+        rows = []
+        for name, task in tasks.items():
+            max_bits = np.log2(len(task["options"]))
+            for mode in MODES:
+                parsed = df[
+                    (df["task"] == name) & (df["mode"] == mode)
+                ]["parsed"].dropna()
+                n = len(parsed)
+                if n == 0:
+                    rows.append({
+                        "task": name,
+                        "mode": mode,
+                        "n_parsed": 0,
+                        "entropy_bits": None,
+                        "max_bits": round(float(max_bits), 2),
+                    })
+                    continue
+                p = parsed.value_counts(normalize=True).to_numpy()
+                h = float(-(p * np.log2(p)).sum())
+                rows.append({
+                    "task": name,
+                    "mode": mode,
+                    "n_parsed": n,
+                    "entropy_bits": round(h, 3),
+                    "max_bits": round(float(max_bits), 2),
+                })
+        return pd.DataFrame(rows)
+
+    entropy_summary = compute_entropy(results, TASKS)
+    entropy_summary
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Reading the chart
+
+    - **Grey — baseline**: prompt asks directly; parsed with a strict regex.
+    - **Blue — SSoT (regex)**: prompt asks for a random 12-character string
+      first, then the answer. Same strict regex (reads after `Answer:` when
+      present, otherwise the whole response).
+    - **Orange — SSoT (tail)**: same generations as blue, but parsed by just
+      taking the last character / word / digit and checking it against the
+      option set. This catches cases where the model scribbles freely and only
+      lands on the real choice at the end.
+
+    Notice a fun thing, the order in which you provide the options might matter!
+    """)
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
## Summary
- Adds `ssot-pif-bias.py`, a marimo notebook partially reproducing *String Seed of Thought* (ICLR 2026): prompts a small local Qwen model for uniform random picks (digit 1–10, letter A–E, coin flip / flip coin) and compares baseline sampling to the SSoT wrapper via grouped-bar charts and Shannon entropy.
- Refines the `implement-paper`, `marimo-batch`, and `marimo-notebook` skill files, and adds a `grid.py` launcher reference for hyperparameter sweeps on top of the batch starting-point.

## Test plan
- [ ] `uv run marimo edit ssot-pif-bias.py` and step through each cell on CPU/MPS with the 0.5B model.
- [ ] Visually confirm the three stacked charts render without horizontal scroll and share a legend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)