### PR TITLE
Add notebooks exploring whether pi contains every number sequence

### DIFF
--- a/pi-batch-count.py
+++ b/pi-batch-count.py
@@ -1,0 +1,259 @@
+# /// script
+# requires-python = ">=3.12,<3.14"
+# dependencies = [
+#     "marimo",
+#     "manim>=0.18.0",
+#     "av>=14.0.0",
+#     "mpmath",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.18.4"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    # Counting **88** in batches across $\pi$
+
+    A manim animation. We take $\pi$'s endless digit stream, **cut it into batches of
+    two**, and slide along counting how often the batch is exactly **88**. We keep a
+    running tally, race through the first **1,000,000** digits, then stop and read off
+    the count.
+    """)
+    return
+
+
+@app.cell
+def _():
+    from mpmath import mp
+
+    # First 1,000,000 decimal digits of pi (~10s to compute).
+    mp.dps = 1_000_050
+    decimals = mp.nstr(mp.pi, 1_000_020, strip_zeros=False).split(".")[1][:1_000_000]
+
+    # Non-overlapping batches of size 2; record which batches equal "88".
+    hits = [j for j in range(len(decimals) // 2) if decimals[2 * j:2 * j + 2] == "88"]
+    count88 = len(hits)
+    return count88, decimals, hits
+
+
+@app.cell
+def _(count88, decimals, hits):
+    import os
+    # Add LaTeX to PATH before importing manim (so it finds latex on import)
+    os.environ["PATH"] = "/Library/TeX/texbin:" + os.environ.get("PATH", "")
+
+    import bisect
+
+    from manim import (
+        Scene, Text, Triangle, VGroup, FadeIn, FadeOut, Write,
+        always_redraw, ValueTracker, rate_functions, PI,
+        UP, DOWN, LEFT, RIGHT, ORIGIN, WHITE, YELLOW, GREY, BLUE,
+    )
+
+    class PiBatchCount(Scene):
+        def construct(self):
+            font_size = 72
+            line_y = -0.5
+            cursor_x = 0.0
+            num_batches = len(decimals) // 2
+
+            ruler = Text("0123456789", font="Monospace", font_size=font_size)
+            w = (ruler[9].get_center()[0] - ruler[0].get_center()[0]) / 9
+            max_gap = 0.9 * w                        # extra space opened between batches
+
+            b = ValueTracker(0.0)                    # batch index sitting at the cursor
+            gap = ValueTracker(0.0)                  # 0 = one stream, 1 = split into pairs
+
+            # Render only the ~15 batches around the cursor, rebuilt each frame.
+            def make_line():
+                bc = b.get_value()
+                slot = 2 * w + gap.get_value() * max_gap
+                cur = int(bc)
+                center = int(round(bc))
+                lo, hi = max(0, center - 7), min(num_batches, center + 8)
+                group = VGroup()
+                for j in range(lo, hi):
+                    pair = decimals[2 * j:2 * j + 2]
+                    chip = Text(pair, font="Monospace", font_size=font_size, color=WHITE)
+                    chip.move_to([cursor_x + (j - bc) * slot, line_y, 0])
+                    if pair == "88" and j <= cur:    # a counted match stays lit
+                        chip.set_color(YELLOW)
+                    elif j == cur:                   # the batch under the cursor
+                        chip.set_color(BLUE)
+                    group.add(chip)
+                return group
+
+            number_line = always_redraw(make_line)
+
+            pointer = Triangle(color=YELLOW, fill_opacity=1).scale(0.12).rotate(PI)
+            pointer.move_to([cursor_x, line_y + 0.85, 0])
+
+            digits_counter = always_redraw(lambda: Text(
+                f"digits checked: {2 * (int(b.get_value()) + 1):,}",
+                font="Monospace", font_size=34, color=WHITE).to_corner(UP + LEFT, buff=0.6))
+            found_counter = always_redraw(lambda: Text(
+                f"88 found: {bisect.bisect_right(hits, int(b.get_value()))}",
+                font="Monospace", font_size=42, color=YELLOW).to_corner(UP + RIGHT, buff=0.6))
+
+            def caption(text):
+                # below the number line, clear of the counters in the top corners
+                return Text(text, font="Monospace", font_size=36, color=GREY).move_to([0, -2.7, 0])
+
+            # ===== intro: the long stream, then cut into batches of two =====
+            self.add(number_line)
+            cap = caption("π's digits — one long stream")
+            self.play(Write(cap))
+            self.wait(1.2)
+            cap2 = caption("cut into batches of 2")
+            self.play(gap.animate.set_value(1.0), FadeOut(cap), FadeIn(cap2), run_time=1.6)
+            self.wait(1.0)
+
+            # ===== bring in the cursor + counters and state the goal =====
+            cap3 = caption("count how often a batch is 88")
+            self.add(digits_counter, found_counter)
+            self.play(FadeIn(pointer), FadeOut(cap2), FadeIn(cap3))
+            self.wait(1.2)
+            self.play(FadeOut(cap3))
+
+            # ===== check the first few pairs slowly (none are 88) =====
+            self.play(b.animate.set_value(6), run_time=3.0, rate_func=rate_functions.linear)
+
+            # ===== land on each of the first three 88s; the tally ticks 1 → 2 → 3 =====
+            cap4 = caption("…there's an 88 — tally it")
+            self.play(b.animate.set_value(hits[0]), run_time=2.6, rate_func=rate_functions.rush_from)
+            self.play(FadeIn(cap4))
+            self.wait(1.2)
+            self.play(b.animate.set_value(hits[1]), run_time=2.2, rate_func=rate_functions.rush_from)
+            self.wait(1.1)
+            self.play(b.animate.set_value(hits[2]), run_time=1.8, rate_func=rate_functions.rush_from)
+            self.wait(1.1)
+            self.play(FadeOut(cap4))
+
+            # ===== fast-forward through the rest, counting every 88 along the way =====
+            cap5 = caption("…fast-forward to 1,000,000 digits")
+            self.play(FadeIn(cap5))
+            self.play(b.animate.set_value(num_batches - 1),
+                      run_time=9.0, rate_func=rate_functions.rush_into)
+            self.play(FadeOut(cap5))
+            self.wait(0.5)
+
+            # ===== stop and read off the count =====
+            for mob in (number_line, pointer, digits_counter, found_counter):
+                mob.clear_updaters()
+            self.play(FadeOut(number_line), FadeOut(pointer),
+                      FadeOut(digits_counter), FadeOut(found_counter))
+            summary = VGroup(
+                Text("first 1,000,000 digits of π", font="Monospace", font_size=40, color=GREY),
+                Text(f"88 appears {count88:,} times", font="Monospace", font_size=66, color=YELLOW),
+            ).arrange(DOWN, buff=0.5).move_to(ORIGIN)
+            self.play(Write(summary))
+            self.wait(2.5)
+
+    return (PiBatchCount,)
+
+
+@app.cell
+def _(mo):
+    # Resolution presets - CLI arg takes precedence
+    _cli_res = mo.cli_args().get("resolution")
+    _default = {
+        "720p": "720p (fast)",
+        "1080p": "1080p (high quality)",
+        "4k": "4K (maximum quality)",
+    }.get(_cli_res, "720p (fast)")
+
+    resolution = mo.ui.dropdown(
+        options={
+            "720p (fast)": "720p",
+            "1080p (high quality)": "1080p",
+            "4K (maximum quality)": "4k",
+        },
+        value=_default,
+        label="Resolution"
+    )
+    return (resolution,)
+
+
+@app.cell
+def _(mo, resolution):
+    # In CLI mode (mo.app_meta().mode == "script"), auto-run. In edit mode, use button.
+    _is_cli = mo.app_meta().mode == "script"
+    render_button = mo.ui.run_button(label="Render Animation")
+    mo.hstack([resolution, render_button], justify="start", gap=1) if not _is_cli else mo.md("*Auto-rendering in CLI mode...*")
+    return (render_button,)
+
+
+@app.cell
+def _(PiBatchCount, mo, render_button, resolution):
+    from pathlib import Path
+
+    # Auto-run in CLI mode, otherwise wait for button
+    _is_cli = mo.app_meta().mode == "script"
+    mo.stop(not _is_cli and not render_button.value)
+
+    # Resolution settings
+    _resolution_presets = {
+        "720p": {"height": 720, "width": 1280, "fps": 30, "folder": "720p30"},
+        "1080p": {"height": 1080, "width": 1920, "fps": 60, "folder": "1080p60"},
+        "4k": {"height": 2160, "width": 3840, "fps": 60, "folder": "2160p60"},
+    }
+    _preset = _resolution_presets[resolution.value]
+
+    # Output directory in the same folder as the notebook
+    _output_dir = Path(__file__).parent / "media" if "__file__" in dir() else Path.cwd() / "media"
+    _output_dir.mkdir(exist_ok=True)
+
+    # Render the scene
+    from manim import config
+    config.media_dir = str(_output_dir)
+    config.pixel_height = _preset["height"]
+    config.pixel_width = _preset["width"]
+    config.frame_rate = _preset["fps"]
+
+    scene = PiBatchCount()
+    scene.render()
+
+    # Find the final output file (not partial files)
+    _video_path = _output_dir / "videos" / _preset["folder"] / "PiBatchCount.mp4"
+
+    if _video_path.exists():
+        with open(_video_path, 'rb') as f:
+            _video_data = f.read()
+        output = mo.vstack([
+            mo.md(f"**Video saved to:** `{_video_path}`"),
+            mo.video(src=_video_data)
+        ])
+    else:
+        output = mo.md("**Error:** Could not find rendered video")
+
+    output
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## What the count means
+
+    With non-overlapping batches of two digits there are **500,000** batches in the
+    first million digits, and each is equally likely to be any of the 100 values
+    `00`–`99`. So **88** should turn up about `500,000 / 100 = 5,000` times — and π
+    delivers **4,988**, right on the money. Same flavour of "π behaves like a random
+    digit stream" as the coupon-collector notebook, seen through a single value.
+    """)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/pi-coupon-collector.py
+++ b/pi-coupon-collector.py
@@ -36,7 +36,7 @@ def _():
     import numpy as np
     from mpmath import mp
 
-    return alt, mo, mp, np, pl
+    return mo, mp
 
 
 @app.cell(hide_code=True)
@@ -77,8 +77,8 @@ def _(digits, mo, pi_query):
                 f"**{s}** isn\u2019t in the first {len(digits):,} digits we computed \u2014 "
                 f"it\u2019s almost surely further out (we just stopped at {len(digits):,})."
             )
-        before = digits[max(0, pos - context):pos]
-        after = digits[pos + len(s):pos + len(s) + context]
+        before = digits[max(0, pos - context) : pos]
+        after = digits[pos + len(s) : pos + len(s) + context]
         return mo.md(
             f"### \U0001f3af Found **{s}** at digit **{pos + 1:,}** of \u03c0\n\n"
             f"\u2026{before}**{s}**{after}\u2026"
@@ -122,8 +122,8 @@ def _(digits_slider, n_batches, prob_slider):
     from scipy.stats import binom
 
     lim_lower, lim_upper = [
-        binom.ppf(prob_slider.value, n_batches, 1/10**digits_slider.value), 
-        binom.ppf(1 - prob_slider.value, n_batches, 1/10**digits_slider.value)
+        binom.ppf(prob_slider.value, n_batches, 1 / 10**digits_slider.value),
+        binom.ppf(1 - prob_slider.value, n_batches, 1 / 10**digits_slider.value),
     ]
 
     lim_lower, lim_upper
@@ -140,7 +140,6 @@ def _(digits, digits_slider):
 
 @app.cell
 def _(digits, digits_slider, it, lim_lower, lim_upper):
-
     import matplotlib.pylab as plt
     from collections import Counter
 
@@ -152,219 +151,9 @@ def _(digits, digits_slider, it, lim_lower, lim_upper):
         if v < lim_lower or v > lim_upper:
             out_of_bounds += 1
 
-    print(f"{out_of_bounds} out of {len(start)}, approx {out_of_bounds/len(start)*100/2}% per side")
-    return
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ---
-    ## Part 1 — Collect every $k$-digit number
-
-    We're gonna read $\pi$ in disjoint chunks of length $k$ and wait until **every**
-    value $0\ldots10^k-1$ has appeared at least once. That's a situation similar to the famous coupon-collector problem. One with $n = 10^k$ coupons.
-    """)
-    return
-
-
-@app.cell(hide_code=True)
-def _(digits):
-    def first_complete(digits, k):
-        """Scan disjoint k-length chunks of `digits`; find when all 10**k values appear.
-
-        Returns the chunk index and digit position where the collection first
-        completes, the straggler value (last to appear), and a running record of
-        (chunk_count, distinct_count) after each chunk for plotting.
-        """
-        universe = 10 ** k
-        seen = set()
-        record = []
-        completed_at_chunk = None
-        last_value = None
-        n_chunks = len(digits) // k
-        for i in range(n_chunks):
-            value = int(digits[i * k:(i + 1) * k])
-            if value not in seen:
-                seen.add(value)
-                if len(seen) == universe and completed_at_chunk is None:
-                    completed_at_chunk = i
-                    last_value = value
-            record.append((i + 1, len(seen)))
-        return {
-            "k": k,
-            "universe": universe,
-            "completed_chunk": completed_at_chunk,
-            "completed_digit_pos": None if completed_at_chunk is None else (completed_at_chunk + 1) * k,
-            "last_value": last_value,
-            "n_seen": len(seen),
-            "record": record,
-        }
-
-
-    K_VALUES = (1, 2, 3, 4)
-    results = {k: first_complete(digits, k) for k in K_VALUES}
-    return (results,)
-
-
-@app.cell(hide_code=True)
-def _(mo, pl, results):
-    def coupon_stats(n):
-        """Mean and standard deviation of the coupon-collector time for n coupons."""
-        mean = n * sum(1.0 / i for i in range(1, n + 1))
-        var = sum((n / (n - j)) ** 2 - (n / (n - j)) for j in range(n))
-        return mean, var ** 0.5
-
-
-    rows = []
-    for k, r in results.items():
-        n = r["universe"]
-        mean_chunks, sd_chunks = coupon_stats(n)
-        chunks = r["completed_chunk"] + 1
-        rows.append({
-            "k": k,
-            "values (10^k)": n,
-            "done @ digit": r["completed_digit_pos"],
-            "chunks needed": chunks,
-            "last value": r["last_value"],
-            "theory mean (chunks)": round(mean_chunks, 1),
-            "theory sd (chunks)": round(sd_chunks, 1),
-            "z-score": round((chunks - mean_chunks) / sd_chunks, 2),
-        })
-
-    summary_df = pl.DataFrame(rows)
-    mo.vstack([
-        mo.md("## Results vs. coupon-collector theory"),
-        summary_df,
-        mo.md(
-            "The **z-score** says how many standard deviations \u03c0's actual "
-            "completion sits from the coupon-collector mean. All four land within "
-            "about one sd \u2014 exactly what you'd expect if \u03c0's digits behave "
-            "like an i.i.d. uniform random stream. No value is anomalously early or late."
-        ),
-    ])
-    return (coupon_stats,)
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ---
-    ## Part 2 — Turning up the resolution
-
-    Collecting *every* $k$-digit number only gives us the points
-    $n = 10, 100, 1000, 10000$ — four spots, exponentially far apart. For a **dense**
-    view we want to coupon-collect a universe of *any* size $n$.
-
-    Clean trick: **fold $\pi$ into $n$ coupons with a mod.** Read $\pi$ in a window of
-    digits wide enough that its value is $\gg n$, take that value $\bmod n$, and you get
-    a draw that's (near-)uniform over $0\ldots n-1$ — exactly one coupon. Collect all
-    $n$ and it takes about $n\cdot H(n)$ steps, the textbook result. Now the universe
-    size is just a slider.
-    """)
-    return
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    n_coupons = mo.ui.slider(2, 1000, value=100, show_value=True,
-                             label="number of coupons n  (fold \u03c0 mod n)")
-    n_coupons
-    return (n_coupons,)
-
-
-@app.cell(hide_code=True)
-def _(coupon_stats, digits, mo, n_coupons):
-    def coupon_steps(digits, n, guard=2):
-        """Steps to collect all n coupons, folding pi into 0..n-1 via mod on wide windows."""
-        w = len(str(n)) + guard          # 10**w >> n, so each draw is near-uniform over 0..n-1
-        seen = set()
-        steps = 0
-        for i in range(len(digits) // w):
-            coupon = int(digits[i * w:(i + 1) * w]) % n
-            steps += 1
-            if coupon not in seen:
-                seen.add(coupon)
-                if len(seen) == n:
-                    return steps
-        return None
-
-
-    demo_w = len(str(n_coupons.value)) + 2
-    demo_steps = coupon_steps(digits, n_coupons.value)
-    demo_mean, demo_sd = coupon_stats(n_coupons.value)
-
-    mo.md(
-        f"Folding \u03c0 into **n = {n_coupons.value}** coupons "
-        f"(reading {demo_w} digits per draw, then mod {n_coupons.value}):  \n\n"
-        f"\u03c0 collects all {n_coupons.value} coupons in **{demo_steps:,} steps**.  \n"
-        f"Theory $n\\cdot H(n) \\approx$ **{demo_mean:,.0f}** steps "
-        f"(\u00b1 {demo_sd:,.0f}), so this run is **{(demo_steps - demo_mean) / demo_sd:+.1f}\u03c3** "
-        f"from the mean."
+    print(
+        f"{out_of_bounds} out of {len(start)}, approx {out_of_bounds / len(start) * 100 / 2}% per side"
     )
-    return (coupon_steps,)
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    n_sweep = mo.ui.slider(10, 1000, value=120, show_value=True,
-                           label="how many n values to sweep (more = denser curve)")
-    n_sweep
-    return (n_sweep,)
-
-
-@app.cell(hide_code=True)
-def _(alt, coupon_steps, digits, mo, n_sweep, np, pl):
-    def sweep_n(n_points, max_n=1000):
-        return sorted(set(int(round(2 + i * (max_n - 2) / (n_points - 1)))
-                          for i in range(n_points)))
-
-
-    def simulate_band(n_values, n_runs=3000, seed=0):
-        """Empirical 10th-90th percentile of coupon-collect time, from real RNG draws."""
-        rng = np.random.default_rng(seed)
-        rows = []
-        for n in n_values:
-            p = np.arange(n, 0, -1) / n                          # P(new coupon) at each stage
-            sims = rng.geometric(p, size=(n_runs, n)).sum(axis=1)  # one full run per row
-            rows.append({"n": n, "p1": float(np.percentile(sims, 1)),
-                         "p99": float(np.percentile(sims, 99))})
-        return pl.DataFrame(rows)
-
-
-    sweep_ns = sweep_n(n_sweep.value)
-    pi_df = pl.DataFrame([{"n": n, "steps": coupon_steps(digits, n)} for n in sweep_ns])
-    band_df = simulate_band(sweep_ns)
-
-    sim_band = (
-        alt.Chart(band_df)
-        .mark_area(color="#9d9d9d", opacity=0.4)
-        .encode(x=alt.X("n:Q", title="number of coupons n"),
-                y=alt.Y("p1:Q", title="steps to collect all n"),
-                y2="p99:Q")
-    )
-    pi_dots = (
-        alt.Chart(pi_df)
-        .mark_circle(size=42, color="#4c78a8")
-        .encode(x="n:Q", y="steps:Q", tooltip=["n", "steps"])
-    )
-    sweep_chart = (sim_band + pi_dots).properties(width=620, height=340)
-
-    mo.vstack([
-        mo.md(
-            "**\u03c0 vs. actual randomness.** The grey band is the 10th\u201390th percentile of "
-            "**simulated** coupon-collector runs on a true random-number generator "
-            "(300 runs per $n$) \u2014 no formula, just rolling dice. Each blue dot is \u03c0's "
-            "single run at that $n$. If \u03c0's digits are random-like, its dots should land "
-            "inside the band about as often as a fresh random source would."
-        ),
-        sweep_chart,
-    ])
-    return
-
-
-@app.cell
-def _():
     return
 
 

--- a/pi-coupon-collector.py
+++ b/pi-coupon-collector.py
@@ -55,7 +55,47 @@ def _(mp):
     # k=4 needs ~390k digits on average (coupon-collector mean); 600k gives headroom.
     N_DIGITS = 1_000_000
     digits = pi_digits(N_DIGITS)
-    return (digits,)
+    return N_DIGITS, digits, pi_digits
+
+
+@app.cell(hide_code=True)
+def _(N_DIGITS, digits, pi_digits):
+    def test_pi_digits_match_known_reference():
+        # pi's first 100 decimal digits (after the point), from a published source.
+        reference = (
+            "1415926535897932384626433832795028841971"
+            "6939937510582097494459230781640628620899"
+            "86280348253421170679"
+        )
+        assert pi_digits(100) == reference
+        assert pi_digits(10) == reference[:10]
+
+
+    def test_pi_digits_prefix_consistency():
+        # A longer computation must agree with shorter ones on the shared prefix,
+        # which catches rounding / precision corruption in the tail.
+        assert pi_digits(2_000)[:100] == pi_digits(100)
+        assert pi_digits(20_000)[:2_000] == pi_digits(2_000)
+
+
+    def test_pi_digits_shape():
+        out = pi_digits(777)
+        assert len(out) == 777
+        assert set(out) <= set("0123456789")
+
+
+    def test_notebook_digits_are_valid():
+        # validate the actual sequence the rest of the notebook relies on
+        reference = (
+            "1415926535897932384626433832795028841971"
+            "6939937510582097494459230781640628620899"
+            "86280348253421170679"
+        )
+        assert len(digits) == N_DIGITS
+        assert digits[:100] == reference
+        assert set(digits) <= set("0123456789")
+
+    return
 
 
 @app.cell(hide_code=True)
@@ -140,7 +180,6 @@ def _(digits, digits_slider):
 
 @app.cell
 def _(digits, digits_slider, it, lim_lower, lim_upper):
-    import matplotlib.pylab as plt
     from collections import Counter
 
     start = Counter({k: 0 for k in it.product("0123456789", repeat=digits_slider.value)})
@@ -154,6 +193,11 @@ def _(digits, digits_slider, it, lim_lower, lim_upper):
     print(
         f"{out_of_bounds} out of {len(start)}, approx {out_of_bounds / len(start) * 100 / 2}% per side"
     )
+    return
+
+
+@app.cell
+def _():
     return
 
 

--- a/pi-coupon-collector.py
+++ b/pi-coupon-collector.py
@@ -1,0 +1,372 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "marimo",
+#     "mpmath",
+#     "polars",
+#     "altair",
+#     "numpy==2.4.6",
+#     "matplotlib==3.10.9",
+#     "scipy==1.17.1",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.23.9"
+app = marimo.App(width="medium")
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    # Is your birthday hiding inside $\pi$?
+
+    $\pi$\u2019s digits run on forever without repeating. Type a number below \u2014 your
+    **birth year** is a fun one \u2014 and we\u2019ll find where it first shows up.
+    """)
+    return
+
+
+@app.cell
+def _():
+    import marimo as mo
+    import polars as pl
+    import altair as alt
+    import numpy as np
+    from mpmath import mp
+
+    return alt, mo, mp, np, pl
+
+
+@app.cell(hide_code=True)
+def _(mp):
+    import sys
+
+
+    def pi_digits(n):
+        """First n decimal digits of pi as a string (the digits after "3.")."""
+        sys.set_int_max_str_digits(max(n + 50, 4300))
+        mp.dps = n + 25
+        scaled = mp.floor(mp.pi * mp.mpf(10) ** n)
+        return str(int(scaled))[1:]
+
+
+    # k=4 needs ~390k digits on average (coupon-collector mean); 600k gives headroom.
+    N_DIGITS = 1_000_000
+    digits = pi_digits(N_DIGITS)
+    return (digits,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    pi_query = mo.ui.text(value="1989", label="a number (try your birth year)")
+    pi_query
+    return (pi_query,)
+
+
+@app.cell(hide_code=True)
+def _(digits, mo, pi_query):
+    def search_view(digits, raw, context=12):
+        s = raw.strip()
+        if not s.isdigit():
+            return mo.md("Type a number (digits only) above \u261d\ufe0f")
+        pos = digits.find(s)
+        if pos < 0:
+            return mo.md(
+                f"**{s}** isn\u2019t in the first {len(digits):,} digits we computed \u2014 "
+                f"it\u2019s almost surely further out (we just stopped at {len(digits):,})."
+            )
+        before = digits[max(0, pos - context):pos]
+        after = digits[pos + len(s):pos + len(s) + context]
+        return mo.md(
+            f"### \U0001f3af Found **{s}** at digit **{pos + 1:,}** of \u03c0\n\n"
+            f"\u2026{before}**{s}**{after}\u2026"
+        )
+
+
+    search_view(digits, pi_query.value)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## But is *every* number in there?
+
+    It seems so.
+
+    But that's not the most interesting thing. It's not just that the numbers are in here. It's that they are in here and it seems that they are randomly distributed in there!
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    digits_slider = mo.ui.slider(1, 4, 1, label="n digits")
+    prob_slider = mo.ui.slider(0.01, 0.10, 0.01, label="prob limit")
+    digits_slider, prob_slider
+    return digits_slider, prob_slider
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    If we look at every number that comes out as a batch.
+    """)
+    return
+
+
+@app.cell
+def _(digits_slider, n_batches, prob_slider):
+    from scipy.stats import binom
+
+    lim_lower, lim_upper = [
+        binom.ppf(prob_slider.value, n_batches, 1/10**digits_slider.value), 
+        binom.ppf(1 - prob_slider.value, n_batches, 1/10**digits_slider.value)
+    ]
+
+    lim_lower, lim_upper
+    return lim_lower, lim_upper
+
+
+@app.cell
+def _(digits, digits_slider):
+    import itertools as it
+
+    n_batches = sum(1 for _ in it.batched(digits, digits_slider.value))
+    return it, n_batches
+
+
+@app.cell
+def _(digits, digits_slider, it, lim_lower, lim_upper):
+
+    import matplotlib.pylab as plt
+    from collections import Counter
+
+    start = Counter({k: 0 for k in it.product("0123456789", repeat=digits_slider.value)})
+    counts = (start + Counter(it.batched(digits, digits_slider.value))).values()
+
+    out_of_bounds = 0
+    for v in counts:
+        if v < lim_lower or v > lim_upper:
+            out_of_bounds += 1
+
+    print(f"{out_of_bounds} out of {len(start)}, approx {out_of_bounds/len(start)*100/2}% per side")
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ---
+    ## Part 1 — Collect every $k$-digit number
+
+    We're gonna read $\pi$ in disjoint chunks of length $k$ and wait until **every**
+    value $0\ldots10^k-1$ has appeared at least once. That's a situation similar to the famous coupon-collector problem. One with $n = 10^k$ coupons.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(digits):
+    def first_complete(digits, k):
+        """Scan disjoint k-length chunks of `digits`; find when all 10**k values appear.
+
+        Returns the chunk index and digit position where the collection first
+        completes, the straggler value (last to appear), and a running record of
+        (chunk_count, distinct_count) after each chunk for plotting.
+        """
+        universe = 10 ** k
+        seen = set()
+        record = []
+        completed_at_chunk = None
+        last_value = None
+        n_chunks = len(digits) // k
+        for i in range(n_chunks):
+            value = int(digits[i * k:(i + 1) * k])
+            if value not in seen:
+                seen.add(value)
+                if len(seen) == universe and completed_at_chunk is None:
+                    completed_at_chunk = i
+                    last_value = value
+            record.append((i + 1, len(seen)))
+        return {
+            "k": k,
+            "universe": universe,
+            "completed_chunk": completed_at_chunk,
+            "completed_digit_pos": None if completed_at_chunk is None else (completed_at_chunk + 1) * k,
+            "last_value": last_value,
+            "n_seen": len(seen),
+            "record": record,
+        }
+
+
+    K_VALUES = (1, 2, 3, 4)
+    results = {k: first_complete(digits, k) for k in K_VALUES}
+    return (results,)
+
+
+@app.cell(hide_code=True)
+def _(mo, pl, results):
+    def coupon_stats(n):
+        """Mean and standard deviation of the coupon-collector time for n coupons."""
+        mean = n * sum(1.0 / i for i in range(1, n + 1))
+        var = sum((n / (n - j)) ** 2 - (n / (n - j)) for j in range(n))
+        return mean, var ** 0.5
+
+
+    rows = []
+    for k, r in results.items():
+        n = r["universe"]
+        mean_chunks, sd_chunks = coupon_stats(n)
+        chunks = r["completed_chunk"] + 1
+        rows.append({
+            "k": k,
+            "values (10^k)": n,
+            "done @ digit": r["completed_digit_pos"],
+            "chunks needed": chunks,
+            "last value": r["last_value"],
+            "theory mean (chunks)": round(mean_chunks, 1),
+            "theory sd (chunks)": round(sd_chunks, 1),
+            "z-score": round((chunks - mean_chunks) / sd_chunks, 2),
+        })
+
+    summary_df = pl.DataFrame(rows)
+    mo.vstack([
+        mo.md("## Results vs. coupon-collector theory"),
+        summary_df,
+        mo.md(
+            "The **z-score** says how many standard deviations \u03c0's actual "
+            "completion sits from the coupon-collector mean. All four land within "
+            "about one sd \u2014 exactly what you'd expect if \u03c0's digits behave "
+            "like an i.i.d. uniform random stream. No value is anomalously early or late."
+        ),
+    ])
+    return (coupon_stats,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ---
+    ## Part 2 — Turning up the resolution
+
+    Collecting *every* $k$-digit number only gives us the points
+    $n = 10, 100, 1000, 10000$ — four spots, exponentially far apart. For a **dense**
+    view we want to coupon-collect a universe of *any* size $n$.
+
+    Clean trick: **fold $\pi$ into $n$ coupons with a mod.** Read $\pi$ in a window of
+    digits wide enough that its value is $\gg n$, take that value $\bmod n$, and you get
+    a draw that's (near-)uniform over $0\ldots n-1$ — exactly one coupon. Collect all
+    $n$ and it takes about $n\cdot H(n)$ steps, the textbook result. Now the universe
+    size is just a slider.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    n_coupons = mo.ui.slider(2, 1000, value=100, show_value=True,
+                             label="number of coupons n  (fold \u03c0 mod n)")
+    n_coupons
+    return (n_coupons,)
+
+
+@app.cell(hide_code=True)
+def _(coupon_stats, digits, mo, n_coupons):
+    def coupon_steps(digits, n, guard=2):
+        """Steps to collect all n coupons, folding pi into 0..n-1 via mod on wide windows."""
+        w = len(str(n)) + guard          # 10**w >> n, so each draw is near-uniform over 0..n-1
+        seen = set()
+        steps = 0
+        for i in range(len(digits) // w):
+            coupon = int(digits[i * w:(i + 1) * w]) % n
+            steps += 1
+            if coupon not in seen:
+                seen.add(coupon)
+                if len(seen) == n:
+                    return steps
+        return None
+
+
+    demo_w = len(str(n_coupons.value)) + 2
+    demo_steps = coupon_steps(digits, n_coupons.value)
+    demo_mean, demo_sd = coupon_stats(n_coupons.value)
+
+    mo.md(
+        f"Folding \u03c0 into **n = {n_coupons.value}** coupons "
+        f"(reading {demo_w} digits per draw, then mod {n_coupons.value}):  \n\n"
+        f"\u03c0 collects all {n_coupons.value} coupons in **{demo_steps:,} steps**.  \n"
+        f"Theory $n\\cdot H(n) \\approx$ **{demo_mean:,.0f}** steps "
+        f"(\u00b1 {demo_sd:,.0f}), so this run is **{(demo_steps - demo_mean) / demo_sd:+.1f}\u03c3** "
+        f"from the mean."
+    )
+    return (coupon_steps,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    n_sweep = mo.ui.slider(10, 1000, value=120, show_value=True,
+                           label="how many n values to sweep (more = denser curve)")
+    n_sweep
+    return (n_sweep,)
+
+
+@app.cell(hide_code=True)
+def _(alt, coupon_steps, digits, mo, n_sweep, np, pl):
+    def sweep_n(n_points, max_n=1000):
+        return sorted(set(int(round(2 + i * (max_n - 2) / (n_points - 1)))
+                          for i in range(n_points)))
+
+
+    def simulate_band(n_values, n_runs=3000, seed=0):
+        """Empirical 10th-90th percentile of coupon-collect time, from real RNG draws."""
+        rng = np.random.default_rng(seed)
+        rows = []
+        for n in n_values:
+            p = np.arange(n, 0, -1) / n                          # P(new coupon) at each stage
+            sims = rng.geometric(p, size=(n_runs, n)).sum(axis=1)  # one full run per row
+            rows.append({"n": n, "p1": float(np.percentile(sims, 1)),
+                         "p99": float(np.percentile(sims, 99))})
+        return pl.DataFrame(rows)
+
+
+    sweep_ns = sweep_n(n_sweep.value)
+    pi_df = pl.DataFrame([{"n": n, "steps": coupon_steps(digits, n)} for n in sweep_ns])
+    band_df = simulate_band(sweep_ns)
+
+    sim_band = (
+        alt.Chart(band_df)
+        .mark_area(color="#9d9d9d", opacity=0.4)
+        .encode(x=alt.X("n:Q", title="number of coupons n"),
+                y=alt.Y("p1:Q", title="steps to collect all n"),
+                y2="p99:Q")
+    )
+    pi_dots = (
+        alt.Chart(pi_df)
+        .mark_circle(size=42, color="#4c78a8")
+        .encode(x="n:Q", y="steps:Q", tooltip=["n", "steps"])
+    )
+    sweep_chart = (sim_band + pi_dots).properties(width=620, height=340)
+
+    mo.vstack([
+        mo.md(
+            "**\u03c0 vs. actual randomness.** The grey band is the 10th\u201390th percentile of "
+            "**simulated** coupon-collector runs on a true random-number generator "
+            "(300 runs per $n$) \u2014 no formula, just rolling dice. Each blue dot is \u03c0's "
+            "single run at that $n$. If \u03c0's digits are random-like, its dots should land "
+            "inside the band about as often as a fresh random source would."
+        ),
+        sweep_chart,
+    ])
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/pi-coupon-collector.py
+++ b/pi-coupon-collector.py
@@ -28,7 +28,7 @@ def _(mo):
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _():
     import marimo as mo
     import polars as pl
@@ -37,65 +37,6 @@ def _():
     from mpmath import mp
 
     return mo, mp
-
-
-@app.cell(hide_code=True)
-def _(mp):
-    import sys
-
-
-    def pi_digits(n):
-        """First n decimal digits of pi as a string (the digits after "3.")."""
-        sys.set_int_max_str_digits(max(n + 50, 4300))
-        mp.dps = n + 25
-        scaled = mp.floor(mp.pi * mp.mpf(10) ** n)
-        return str(int(scaled))[1:]
-
-
-    # k=4 needs ~390k digits on average (coupon-collector mean); 600k gives headroom.
-    N_DIGITS = 1_000_000
-    digits = pi_digits(N_DIGITS)
-    return N_DIGITS, digits, pi_digits
-
-
-@app.cell(hide_code=True)
-def _(N_DIGITS, digits, pi_digits):
-    def test_pi_digits_match_known_reference():
-        # pi's first 100 decimal digits (after the point), from a published source.
-        reference = (
-            "1415926535897932384626433832795028841971"
-            "6939937510582097494459230781640628620899"
-            "86280348253421170679"
-        )
-        assert pi_digits(100) == reference
-        assert pi_digits(10) == reference[:10]
-
-
-    def test_pi_digits_prefix_consistency():
-        # A longer computation must agree with shorter ones on the shared prefix,
-        # which catches rounding / precision corruption in the tail.
-        assert pi_digits(2_000)[:100] == pi_digits(100)
-        assert pi_digits(20_000)[:2_000] == pi_digits(2_000)
-
-
-    def test_pi_digits_shape():
-        out = pi_digits(777)
-        assert len(out) == 777
-        assert set(out) <= set("0123456789")
-
-
-    def test_notebook_digits_are_valid():
-        # validate the actual sequence the rest of the notebook relies on
-        reference = (
-            "1415926535897932384626433832795028841971"
-            "6939937510582097494459230781640628620899"
-            "86280348253421170679"
-        )
-        assert len(digits) == N_DIGITS
-        assert digits[:100] == reference
-        assert set(digits) <= set("0123456789")
-
-    return
 
 
 @app.cell(hide_code=True)
@@ -196,8 +137,62 @@ def _(digits, digits_slider, it, lim_lower, lim_upper):
     return
 
 
-@app.cell
-def _():
+@app.cell(hide_code=True)
+def _(mp):
+    import sys
+
+
+    def pi_digits(n):
+        """First n decimal digits of pi as a string (the digits after "3.")."""
+        sys.set_int_max_str_digits(max(n + 50, 4300))
+        mp.dps = n + 25
+        scaled = mp.floor(mp.pi * mp.mpf(10) ** n)
+        return str(int(scaled))[1:]
+
+
+    # k=4 needs ~390k digits on average (coupon-collector mean); 600k gives headroom.
+    N_DIGITS = 1_000_000
+    digits = pi_digits(N_DIGITS)
+    return N_DIGITS, digits, pi_digits
+
+
+@app.cell(hide_code=True)
+def _(N_DIGITS, digits, pi_digits):
+    def test_pi_digits_match_known_reference():
+        # pi's first 100 decimal digits (after the point), from a published source.
+        reference = (
+            "1415926535897932384626433832795028841971"
+            "6939937510582097494459230781640628620899"
+            "86280348253421170679"
+        )
+        assert pi_digits(100) == reference
+        assert pi_digits(10) == reference[:10]
+
+
+    def test_pi_digits_prefix_consistency():
+        # A longer computation must agree with shorter ones on the shared prefix,
+        # which catches rounding / precision corruption in the tail.
+        assert pi_digits(2_000)[:100] == pi_digits(100)
+        assert pi_digits(20_000)[:2_000] == pi_digits(2_000)
+
+
+    def test_pi_digits_shape():
+        out = pi_digits(777)
+        assert len(out) == 777
+        assert set(out) <= set("0123456789")
+
+
+    def test_notebook_digits_are_valid():
+        # validate the actual sequence the rest of the notebook relies on
+        reference = (
+            "1415926535897932384626433832795028841971"
+            "6939937510582097494459230781640628620899"
+            "86280348253421170679"
+        )
+        assert len(digits) == N_DIGITS
+        assert digits[:100] == reference
+        assert set(digits) <= set("0123456789")
+
     return
 
 

--- a/pi-digit-hunt.py
+++ b/pi-digit-hunt.py
@@ -1,0 +1,223 @@
+# /// script
+# requires-python = ">=3.12,<3.14"
+# dependencies = [
+#     "marimo",
+#     "manim>=0.18.0",
+#     "av>=14.0.0",
+#     "mpmath",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.18.4"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    # Hunting for numbers inside $\pi$
+
+    A manim animation. We start with $\pi$ and its decimal expansion
+    $3.14159\ldots$, then scroll the digits leftward like a tape past a fixed
+    reading frame. We slow down as the sequence **19** arrives, freeze on it, and
+    show its position. Then the same hunt — a bit faster — for **1988**, which
+    lives much deeper in $\pi$.
+    """)
+    return
+
+
+@app.cell
+def _():
+    from mpmath import mp
+
+    mp.dps = 4900
+    # decimals after the "3." — enough to cover 8888 (index 4751) plus context
+    decimals = mp.nstr(mp.pi, 4850, strip_zeros=False).split(".")[1][:4800]
+    return (decimals,)
+
+
+@app.cell
+def _(decimals):
+    import os
+    # Add LaTeX to PATH before importing manim (so it finds latex on import)
+    os.environ["PATH"] = "/Library/TeX/texbin:" + os.environ.get("PATH", "")
+
+    from manim import (
+        Scene, Text, MathTex, Triangle, FadeIn, Write,
+        always_redraw, ValueTracker, rate_functions, PI,
+        UP, RIGHT, ORIGIN, WHITE, YELLOW,
+    )
+
+    class PiDigitHunt(Scene):
+        def construct(self):
+            full = "3." + decimals          # the digit stream; char 2 onward are decimals
+            font_size = 84                  # big digits
+            line_y = -2.6                   # the number line sits below the centered pi
+            frame_x = 0.0                   # the reading cursor (screen centre)
+
+            # uniform monospace advance, measured once at this font size
+            ruler = Text("0123456789", font="Monospace", font_size=font_size)
+            w = (ruler[9].get_center()[0] - ruler[0].get_center()[0]) / 9
+
+            t = ValueTracker(0.0)           # fractional char-index of `full` at the cursor
+            found = []                      # [(char_start, char_end)] to paint yellow
+
+            # Render only the ~40 digits around the cursor, rebuilt every frame. Avoids
+            # ever holding one giant 1500-glyph mobject (which manim fails to re-render).
+            def make_line():
+                c = t.get_value()
+                mid = int(round(c))
+                lo, hi = max(0, mid - 20), min(len(full), mid + 20)
+                line = Text(full[lo:hi], font="Monospace", font_size=font_size, color=WHITE)
+                line.set_y(line_y)
+                line.shift(RIGHT * ((frame_x - (c - lo) * w) - line[0].get_center()[0]))
+                for cs, ce in found:                       # keep matches lit as they pass
+                    for i in range(cs, ce):
+                        if lo <= i < hi:
+                            line[i - lo].set_color(YELLOW)
+                return line
+
+            number_line = always_redraw(make_line)
+
+            # Ticking index counter — the index itself, no explanatory sentence.
+            counter = always_redraw(
+                lambda: Text(f"digit {max(0, round(t.get_value()) - 1)}",
+                             font="Monospace", font_size=46, color=YELLOW)
+                .to_corner(UP + RIGHT, buff=0.6)
+            )
+
+            pointer = Triangle(color=YELLOW, fill_opacity=1).scale(0.13).rotate(PI)
+            pointer.move_to([frame_x, line_y + 0.95, 0])
+
+            pi_sym = MathTex(r"\pi", font_size=240).move_to(ORIGIN)
+
+            # ===== intro: big centred pi, then the number line beneath it =====
+            self.play(Write(pi_sym))
+            self.wait(0.4)
+            head = Text(full[:20], font="Monospace", font_size=font_size, color=WHITE)
+            head.set_y(line_y)
+            head.shift(RIGHT * (frame_x - head[0].get_center()[0]))
+            self.play(Write(head), FadeIn(pointer))
+            self.wait(0.8)
+            self.remove(head)                              # swap to the live sliding window
+            self.add(number_line, counter)
+
+            def lock_on(target, start):                    # light up the match, then hold
+                found.append((start, start + len(target)))
+                self.wait(1.8)
+
+            def accel_cruise_decel(a, ramp=0.45):
+                # trapezoidal velocity: constant acceleration up, a high-speed cruise,
+                # then constant deceleration down — area (total distance) normalised to 1.
+                v = 1.0 / (1.0 - ramp)                     # cruise speed
+                if a < ramp:                               # ramping up
+                    return v * a * a / (2 * ramp)
+                if a < 1 - ramp:                           # cruising
+                    return v * ramp / 2 + v * (a - ramp)
+                b = a - (1 - ramp)                         # ramping down
+                p0 = v * ramp / 2 + v * (1 - 2 * ramp)
+                return p0 + v * b - v * b * b / (2 * ramp)
+
+            # hunt 1: "19" (37th digit) — slow & steady, decelerate onto it
+            s1 = full.find("19")
+            self.play(t.animate.set_value(s1 - 8), run_time=3.2, rate_func=rate_functions.linear)
+            self.play(t.animate.set_value(s1), run_time=2.2, rate_func=rate_functions.rush_from)
+            lock_on("19", s1)
+
+            # hunt 2: "8888" (4751st digit) — accelerate gently, cruise fast, then slow onto it
+            s2 = full.find("8888")
+            self.play(t.animate.set_value(s2), run_time=11.0, rate_func=accel_cruise_decel)
+            lock_on("8888", s2)
+            self.wait(1.5)
+
+    return (PiDigitHunt,)
+
+
+@app.cell
+def _(mo):
+    # Resolution presets - CLI arg takes precedence
+    _cli_res = mo.cli_args().get("resolution")
+    _default = {
+        "720p": "720p (fast)",
+        "1080p": "1080p (high quality)",
+        "4k": "4K (maximum quality)",
+    }.get(_cli_res, "720p (fast)")
+
+    resolution = mo.ui.dropdown(
+        options={
+            "720p (fast)": "720p",
+            "1080p (high quality)": "1080p",
+            "4K (maximum quality)": "4k",
+        },
+        value=_default,
+        label="Resolution"
+    )
+    return (resolution,)
+
+
+@app.cell
+def _(mo, resolution):
+    # In CLI mode (mo.app_meta().mode == "script"), auto-run. In edit mode, use button.
+    _is_cli = mo.app_meta().mode == "script"
+    render_button = mo.ui.run_button(label="Render Animation")
+    mo.hstack([resolution, render_button], justify="start", gap=1) if not _is_cli else mo.md("*Auto-rendering in CLI mode...*")
+    return (render_button,)
+
+
+@app.cell
+def _(PiDigitHunt, mo, render_button, resolution):
+    from pathlib import Path
+
+    # Auto-run in CLI mode, otherwise wait for button
+    _is_cli = mo.app_meta().mode == "script"
+    mo.stop(not _is_cli and not render_button.value)
+
+    # Resolution settings
+    _resolution_presets = {
+        "720p": {"height": 720, "width": 1280, "fps": 30, "folder": "720p30"},
+        "1080p": {"height": 1080, "width": 1920, "fps": 60, "folder": "1080p60"},
+        "4k": {"height": 2160, "width": 3840, "fps": 60, "folder": "2160p60"},
+    }
+    _preset = _resolution_presets[resolution.value]
+
+    # Output directory in the same folder as the notebook
+    _output_dir = Path(__file__).parent / "media" if "__file__" in dir() else Path.cwd() / "media"
+    _output_dir.mkdir(exist_ok=True)
+
+    # Render the scene
+    from manim import config
+    config.media_dir = str(_output_dir)
+    config.pixel_height = _preset["height"]
+    config.pixel_width = _preset["width"]
+    config.frame_rate = _preset["fps"]
+
+    scene = PiDigitHunt()
+    scene.render()
+
+    # Find the final output file (not partial files)
+    _video_path = _output_dir / "videos" / _preset["folder"] / "PiDigitHunt.mp4"
+
+    if _video_path.exists():
+        with open(_video_path, 'rb') as f:
+            _video_data = f.read()
+        output = mo.vstack([
+            mo.md(f"**Video saved to:** `{_video_path}`"),
+            mo.video(src=_video_data)
+        ])
+    else:
+        output = mo.md("**Error:** Could not find rendered video")
+
+    output
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/pi-digit-hunt.py
+++ b/pi-digit-hunt.py
@@ -112,7 +112,10 @@ def _(decimals):
 
             def lock_on(target, start):                    # light up the match, then hold
                 found.append((start, start + len(target)))
-                self.wait(1.8)
+                # a brief no-movement play forces a live frame so the new highlight is
+                # actually drawn (a bare self.wait would just hold the pre-highlight frame).
+                self.play(t.animate.set_value(start), run_time=0.5)
+                self.wait(1.5)
 
             def accel_cruise_decel(a, ramp=0.45):
                 # trapezoidal velocity: constant acceleration up, a high-speed cruise,


### PR DESCRIPTION
Adds three marimo notebooks exploring whether π contains every number sequence (its conjectured normality). `pi-coupon-collector.py` is the main interactive notebook: type a number (e.g. your birth year) to find where it first appears in π's digits, then a coupon-collector exploration that folds π into `n` coupons via a mod slider and compares π's single runs against a band of simulated random draws — plus unit tests verifying the digit generation against a known reference, prefix-consistency at scale, and the live 1M-digit sequence. `pi-digit-hunt.py` and `pi-batch-count.py` are manim-animation notebooks that visualize hunting for a number in π's scrolling digit tape and counting how often a two-digit batch (e.g. `88`) recurs across the stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)