### PR TITLE
Add archive test hook

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -2,4 +2,5 @@
 
 [scripts]
 setup = "cp \"$CONDUCTOR_ROOT_PATH/.env\" ."
+archive = "sleep 5"
 run_mode = "concurrent"


### PR DESCRIPTION
Adds a Conductor archive script that sleeps for five seconds. This makes it easy to confirm that the archive hook is being invoked.